### PR TITLE
[codex] Avoid redundant VeSync detail refreshes

### DIFF
--- a/src/accessories/air-quality-sensor.accessory.ts
+++ b/src/accessories/air-quality-sensor.accessory.ts
@@ -240,8 +240,11 @@ export class AirQualitySensorAccessory extends BaseAccessory {
     try {
       // Make sure device data is current
       const extendedDevice = this.parentDevice as any;
-      if (typeof extendedDevice.getDetails === 'function') {
+      if (this.isDeviceOffline(extendedDevice)) {
+        this.platform.log.debug(`${this.device.deviceName} AQ: Skipping refresh because parent device is offline`);
+      } else if (!this.hasFreshDeviceDetails() && typeof extendedDevice.getDetails === 'function') {
         await extendedDevice.getDetails();
+        this.cacheDeviceDetails(extendedDevice);
       }
       
       // Update air quality

--- a/src/accessories/base.accessory.ts
+++ b/src/accessories/base.accessory.ts
@@ -135,12 +135,13 @@ export abstract class BaseAccessory {
         const deviceWithDetails = this.device as any;
         if (typeof deviceWithDetails.getDetails === 'function') {
           const now = Date.now();
-          const shouldUseCache = this.deviceDetailsCache !== null && 
-                                (now - this.lastDetailsFetch < this.CACHE_TTL);
+          const shouldUseCache = this.hasFreshDeviceDetails(now);
           
-          if (shouldUseCache) {
+          if (this.isDeviceOffline(deviceWithDetails)) {
+            this.logger.debug('Skipping device details refresh during initialization because device is offline', this.getLogContext());
+          } else if (shouldUseCache) {
             this.logger.debug('Using cached device details during initialization', this.getLogContext());
-            Object.assign(deviceWithDetails, this.deviceDetailsCache);
+            this.applyCachedDeviceDetails(deviceWithDetails);
           } else {
             this.logger.debug('Refreshing device details during initialization', this.getLogContext());
             const refreshResult = await deviceWithDetails.getDetails();
@@ -150,8 +151,7 @@ export abstract class BaseAccessory {
               this.logger.warn('Device refresh skipped due to API quota limits during initialization', this.getLogContext());
             } else {
               this.logger.debug(`Device status after refresh: ${this.device.deviceStatus}`, this.getLogContext());
-              this.deviceDetailsCache = { ...deviceWithDetails };
-              this.lastDetailsFetch = now;
+              this.cacheDeviceDetails(deviceWithDetails, now);
             }
           }
         }
@@ -179,6 +179,26 @@ export abstract class BaseAccessory {
   private lastDetailsFetch = 0;
   private readonly CACHE_TTL = 60 * 1000; // 1 minute cache TTL
 
+  protected isDeviceOffline(device: any = this.device): boolean {
+    return String(device?.connectionStatus || '').toLowerCase() === 'offline';
+  }
+
+  protected hasFreshDeviceDetails(now = Date.now()): boolean {
+    return this.deviceDetailsCache !== null &&
+      (now - this.lastDetailsFetch < this.CACHE_TTL);
+  }
+
+  protected applyCachedDeviceDetails(deviceWithDetails: any): void {
+    if (this.deviceDetailsCache) {
+      Object.assign(deviceWithDetails, this.deviceDetailsCache);
+    }
+  }
+
+  protected cacheDeviceDetails(deviceWithDetails: any, fetchedAt = Date.now()): void {
+    this.deviceDetailsCache = { ...deviceWithDetails };
+    this.lastDetailsFetch = fetchedAt;
+  }
+
   /**
    * Update the underlying device instance with the latest state from the VeSync client.
    *
@@ -189,8 +209,7 @@ export abstract class BaseAccessory {
    */
   public applyUpdatedDeviceState(updatedDevice: VeSyncDeviceWithPower): void {
     Object.assign(this.device as any, updatedDevice);
-    this.deviceDetailsCache = { ...(this.device as any) };
-    this.lastDetailsFetch = Date.now();
+    this.cacheDeviceDetails(this.device as any);
   }
 
   /**
@@ -204,15 +223,14 @@ export abstract class BaseAccessory {
         const deviceWithDetails = this.device as any;
         if (typeof deviceWithDetails.getDetails === 'function') {
           const now = Date.now();
-          const shouldUseCache = this.deviceDetailsCache !== null && 
-                                (now - this.lastDetailsFetch < this.CACHE_TTL);
+          const shouldUseCache = this.hasFreshDeviceDetails(now);
           
-          if (shouldUseCache) {
+          if (this.isDeviceOffline(deviceWithDetails)) {
+            this.logger.debug('Skipping device details refresh because device is offline', this.getLogContext());
+          } else if (shouldUseCache) {
             this.logger.debug('Using cached device details', this.getLogContext());
             // Apply cached details to device if available
-            if (this.deviceDetailsCache) {
-              Object.assign(deviceWithDetails, this.deviceDetailsCache);
-            }
+            this.applyCachedDeviceDetails(deviceWithDetails);
           } else {
             this.logger.debug('Refreshing device details during sync', this.getLogContext());
             const refreshResult = await deviceWithDetails.getDetails();
@@ -224,8 +242,7 @@ export abstract class BaseAccessory {
             } else {
               this.logger.debug(`Device status after refresh: ${this.device.deviceStatus}`, this.getLogContext());
               // Update cache with fresh data
-              this.deviceDetailsCache = { ...deviceWithDetails };
-              this.lastDetailsFetch = now;
+              this.cacheDeviceDetails(deviceWithDetails, now);
             }
           }
         }

--- a/src/accessories/humidifier.accessory.ts
+++ b/src/accessories/humidifier.accessory.ts
@@ -641,7 +641,9 @@ export class HumidifierAccessory extends BaseAccessory {
     
     // First, refresh the device details to ensure we have the latest state
     try {
-      if (typeof extendedDevice.getDetails === 'function') {
+      if (this.isDeviceOffline(extendedDevice)) {
+        this.platform.log.debug(`Skipping refresh for offline humidifier: ${this.device.deviceName}`);
+      } else if (!this.hasFreshDeviceDetails() && typeof extendedDevice.getDetails === 'function') {
         await extendedDevice.getDetails();
         // Log only specific properties to avoid circular references
         this.platform.log.debug(
@@ -651,6 +653,7 @@ export class HumidifierAccessory extends BaseAccessory {
           `Humidity: ${extendedDevice.humidity}, ` +
           `MistLevel: ${extendedDevice.mistLevel}`
         );
+        this.cacheDeviceDetails(extendedDevice);
       }
     } catch (error) {
       this.platform.log.warn(`Failed to refresh device details: ${error}`);


### PR DESCRIPTION
## Summary
- Skip accessory detail refreshes when VeSync reports the device or parent device offline.
- Add shared cache/offline helpers in `BaseAccessory`.
- Avoid redundant humidifier and air-quality `getDetails()` calls when the base accessory already has fresh details.

## Why
The Homebridge plugin was asking the same VeSync detail endpoints multiple times during each refresh. For intentionally offline devices, those calls produced repeated offline/controller-offline log errors. For online purifiers, the extra calls increased the chance of intermittent device timeout errors.

## Validation
- `npm install`
- `npm run build`

Note: validation host is Node 18.19.1, so npm emitted the existing engine warning for repos requiring Node 18.20.4+.
