### PR TITLE
[codex] Allow Vital refresh when list reports offline

### DIFF
--- a/src/__tests__/base.accessory.test.ts
+++ b/src/__tests__/base.accessory.test.ts
@@ -68,6 +68,7 @@ describe('BaseAccessory', () => {
     mockLogger = {
       debug: jest.fn(),
       info: jest.fn(),
+      success: jest.fn(),
       warn: jest.fn(),
       error: jest.fn(),
       log: jest.fn(),
@@ -122,6 +123,7 @@ describe('BaseAccessory', () => {
       api: {
         updatePlatformAccessories: jest.fn().mockImplementation((accessories: PlatformAccessory[]) => {}),
       },
+      isReady: jest.fn().mockResolvedValue(undefined),
       config: {
         platform: 'TSVESync',
         name: 'TSVESync',
@@ -234,6 +236,63 @@ describe('BaseAccessory', () => {
       const updateSpy = jest.spyOn(accessory as any, 'updateDeviceSpecificStates');
       await accessory.syncDeviceState();
       expect(updateSpy).toHaveBeenCalledWith(mockDevice);
+    });
+
+    it('syncDeviceState skips detail refresh for generic offline devices', async () => {
+      mockDevice.connectionStatus = 'offline';
+      mockDevice.deviceType = 'ESW15-USA';
+      mockDevice.getDetails.mockResolvedValue(true);
+
+      await accessory.syncDeviceState();
+
+      expect(mockDevice.getDetails).not.toHaveBeenCalled();
+    });
+
+    it('syncDeviceState refreshes Vital devices even when the device list says offline', async () => {
+      mockDevice.connectionStatus = 'offline';
+      mockDevice.deviceType = 'LAP-V102S-AASR';
+      mockDevice.getDetails.mockResolvedValue(true);
+
+      await accessory.syncDeviceState();
+
+      expect(mockDevice.getDetails).toHaveBeenCalledTimes(1);
+    });
+
+    it('syncDeviceState honors device-level offline polling opt-in', async () => {
+      mockDevice.connectionStatus = 'offline';
+      mockDevice.deviceType = 'unknown';
+      mockDevice.shouldPollDetailsWhenOffline = jest.fn().mockReturnValue(true);
+      mockDevice.getDetails.mockResolvedValue(true);
+
+      await accessory.syncDeviceState();
+
+      expect(mockDevice.getDetails).toHaveBeenCalledTimes(1);
+    });
+
+    it('syncDeviceState refreshes Vital devices after an offline list update is applied', async () => {
+      mockDevice.connectionStatus = 'online';
+      mockDevice.deviceType = 'LAP-V102S-AASR';
+      mockDevice.getDetails.mockResolvedValue(true);
+
+      accessory.applyUpdatedDeviceState({
+        ...mockDevice,
+        connectionStatus: 'offline',
+        deviceStatus: 'off',
+      });
+
+      await accessory.syncDeviceState();
+
+      expect(mockDevice.getDetails).toHaveBeenCalledTimes(1);
+    });
+
+    it('initialize refreshes Everest devices even when the device list says offline', async () => {
+      mockDevice.connectionStatus = 'offline';
+      mockDevice.deviceType = 'LAP-EL551S-AUS';
+      mockDevice.getDetails.mockResolvedValue(true);
+
+      await accessory.initialize();
+
+      expect(mockDevice.getDetails).toHaveBeenCalledTimes(1);
     });
 
     it('syncDeviceState swallows update errors and logs', async () => {

--- a/src/accessories/air-quality-sensor.accessory.ts
+++ b/src/accessories/air-quality-sensor.accessory.ts
@@ -240,7 +240,7 @@ export class AirQualitySensorAccessory extends BaseAccessory {
     try {
       // Make sure device data is current
       const extendedDevice = this.parentDevice as any;
-      if (this.isDeviceOffline(extendedDevice)) {
+      if (this.shouldSkipDeviceDetailsRefresh(extendedDevice)) {
         this.platform.log.debug(`${this.device.deviceName} AQ: Skipping refresh because parent device is offline`);
       } else if (!this.hasFreshDeviceDetails() && typeof extendedDevice.getDetails === 'function') {
         await extendedDevice.getDetails();

--- a/src/accessories/base.accessory.ts
+++ b/src/accessories/base.accessory.ts
@@ -137,7 +137,7 @@ export abstract class BaseAccessory {
           const now = Date.now();
           const shouldUseCache = this.hasFreshDeviceDetails(now);
           
-          if (this.isDeviceOffline(deviceWithDetails)) {
+          if (this.shouldSkipDeviceDetailsRefresh(deviceWithDetails)) {
             this.logger.debug('Skipping device details refresh during initialization because device is offline', this.getLogContext());
           } else if (shouldUseCache) {
             this.logger.debug('Using cached device details during initialization', this.getLogContext());
@@ -183,6 +183,19 @@ export abstract class BaseAccessory {
     return String(device?.connectionStatus || '').toLowerCase() === 'offline';
   }
 
+  protected shouldRefreshDetailsWhenOffline(device: any = this.device): boolean {
+    if (typeof device?.shouldPollDetailsWhenOffline === 'function') {
+      return Boolean(device.shouldPollDetailsWhenOffline());
+    }
+
+    const deviceType = String(device?.deviceType || '').toUpperCase();
+    return deviceType.startsWith('LAP-V') || deviceType.startsWith('LAP-EL');
+  }
+
+  protected shouldSkipDeviceDetailsRefresh(device: any = this.device): boolean {
+    return this.isDeviceOffline(device) && !this.shouldRefreshDetailsWhenOffline(device);
+  }
+
   protected hasFreshDeviceDetails(now = Date.now()): boolean {
     return this.deviceDetailsCache !== null &&
       (now - this.lastDetailsFetch < this.CACHE_TTL);
@@ -209,6 +222,11 @@ export abstract class BaseAccessory {
    */
   public applyUpdatedDeviceState(updatedDevice: VeSyncDeviceWithPower): void {
     Object.assign(this.device as any, updatedDevice);
+    if (this.isDeviceOffline(this.device) && this.shouldRefreshDetailsWhenOffline(this.device)) {
+      this.logger.debug('Not caching offline device-list state because details refresh is still allowed', this.getLogContext());
+      return;
+    }
+
     this.cacheDeviceDetails(this.device as any);
   }
 
@@ -225,7 +243,7 @@ export abstract class BaseAccessory {
           const now = Date.now();
           const shouldUseCache = this.hasFreshDeviceDetails(now);
           
-          if (this.isDeviceOffline(deviceWithDetails)) {
+          if (this.shouldSkipDeviceDetailsRefresh(deviceWithDetails)) {
             this.logger.debug('Skipping device details refresh because device is offline', this.getLogContext());
           } else if (shouldUseCache) {
             this.logger.debug('Using cached device details', this.getLogContext());


### PR DESCRIPTION
## Summary
- allow Vital/Everest purifier accessories to refresh details even when the VeSync device list reports offline
- avoid caching offline list-only snapshots for those models, so sparse list state does not overwrite the last good detail cache
- reuse the same decision for the separate air-quality accessory
- add regression coverage for generic offline devices, Vital/Everest offline-list devices, offline-list cache updates, and the new tsvesync device-level opt-in hook

## Root cause
`homebridge-tsvesync@1.4.10` skipped local `getDetails()` refreshes whenever `connectionStatus` was `offline`, and it also cached the latest device-list snapshot after `client.update()`. Some Vital 100S/Vital/Everest bypassV2 purifiers can still return valid detail and control responses while the list endpoint reports offline, so HomeKit could treat sparse list-only state as fresh and show the purifier off with bad filter data.

Fixes #37. Complements mickgiles/tsvesync#4, which applies the same model-specific behavior inside the library manager update loop.

## Validation
- `npm run build`
- `npx jest src/__tests__/base.accessory.test.ts --runInBand`

Note: local npm install emitted the existing Node engine warning because this host is on Node 18.19.1 and the package requires 18.20.4+; npm audit also reported existing high-severity dependency findings.