### PR TITLE
Expose Pet mode as a HomeKit switch for Vital purifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 18.20.4
+          - 20.15.1
+          - 22
+          - 24
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm install
+      - name: Lint
+        run: npm run lint
+      - name: Build
+        run: npm run build
+      - name: Test
+        run: npm test -- --runInBand

--- a/src/__tests__/accessories/air-purifier-pet-mode.test.ts
+++ b/src/__tests__/accessories/air-purifier-pet-mode.test.ts
@@ -1,0 +1,229 @@
+import { API, CharacteristicValue, Logger } from 'homebridge';
+import { VeSync } from 'tsvesync';
+import { AirPurifierAccessory } from '../../accessories/air-purifier.accessory';
+import { TSVESyncPlatform } from '../../platform';
+import {
+  createMockInfoService,
+  createMockLogger,
+  createMockService,
+  createMockVeSync,
+} from '../utils/test-helpers';
+
+interface PetModeHarnessOptions {
+  autoCapable?: boolean;
+  existingPetService?: boolean;
+  petCapable?: boolean;
+}
+
+interface PetModeHandlers {
+  get?: () => Promise<CharacteristicValue>;
+  set?: (value: CharacteristicValue) => Promise<void>;
+}
+
+describe('AirPurifierAccessory Pet Mode switch', () => {
+  function createHarness(options: PetModeHarnessOptions = {}) {
+    const {
+      autoCapable = true,
+      existingPetService = false,
+      petCapable = true,
+    } = options;
+    const logger = createMockLogger();
+    const api = createMockVeSync();
+    const mockAPI = {
+      hap: {
+        Characteristic: {
+          Active: 'Active',
+          CurrentAirPurifierState: 'CurrentAirPurifierState',
+          FilterChangeIndication: 'FilterChangeIndication',
+          FilterLifeLevel: 'FilterLifeLevel',
+          Manufacturer: 'Manufacturer',
+          Model: 'Model',
+          Name: 'Name',
+          On: 'On',
+          RotationSpeed: 'RotationSpeed',
+          SerialNumber: 'SerialNumber',
+          TargetAirPurifierState: 'TargetAirPurifierState',
+        },
+        Service: {
+          AccessoryInformation: 'AccessoryInformation',
+          AirPurifier: 'AirPurifier',
+          AirQualitySensor: 'AirQualitySensor',
+          FilterMaintenance: 'FilterMaintenance',
+          Switch: 'Switch',
+        },
+        uuid: {
+          generate: jest.fn(),
+        },
+      },
+      platformAccessory: jest.fn(),
+    } as unknown as jest.Mocked<API>;
+    const platform = new TSVESyncPlatform(logger as jest.Mocked<Logger>, {} as any, mockAPI);
+    (platform as any).api = api as jest.Mocked<VeSync>;
+
+    const primaryService = {
+      ...createMockService(),
+      updateCharacteristic: jest.fn().mockReturnThis(),
+    };
+    const infoService = createMockInfoService();
+    const petModeHandlers: PetModeHandlers = {};
+    const petModeCharacteristic = {
+      onGet: jest.fn((handler: PetModeHandlers['get']) => {
+        petModeHandlers.get = handler;
+        return petModeCharacteristic;
+      }),
+      onSet: jest.fn((handler: PetModeHandlers['set']) => {
+        petModeHandlers.set = handler;
+        return petModeCharacteristic;
+      }),
+    };
+    const stalePetService = existingPetService ? {
+      ...createMockService(),
+      updateCharacteristic: jest.fn().mockReturnThis(),
+    } : undefined;
+    let petModeService = stalePetService;
+
+    const accessory = {
+      context: {},
+      getService: jest.fn((service: any) => {
+        if (service === mockAPI.hap.Service.AccessoryInformation) return infoService;
+        if (service === mockAPI.hap.Service.AirPurifier) return primaryService;
+        if (service === 'Pet Mode') return petModeService;
+        return undefined;
+      }),
+      addService: jest.fn((service: any) => {
+        if (service !== mockAPI.hap.Service.Switch) return primaryService;
+        petModeService = {
+          ...createMockService(),
+          getCharacteristic: jest.fn(() => petModeCharacteristic),
+          updateCharacteristic: jest.fn().mockReturnThis(),
+        };
+        return petModeService;
+      }),
+      removeService: jest.fn(),
+    };
+
+    const features = new Set([
+      'fan_speed',
+      'filter_life',
+      ...(autoCapable ? ['auto_mode'] : []),
+      ...(petCapable ? ['pet_mode'] : []),
+    ]);
+    const device: any = {
+      autoMode: jest.fn(),
+      changeFanSpeed: jest.fn().mockResolvedValue(true),
+      connectionStatus: 'online',
+      details: {
+        enabled: true,
+        filter_life: 80,
+        mode: 'manual',
+        speed: 2,
+      },
+      deviceName: 'Vital Test Unit',
+      deviceStatus: 'on',
+      deviceType: 'LAP-V201S-WUS',
+      enabled: true,
+      filterLife: 80,
+      getDetails: jest.fn().mockResolvedValue(true),
+      getMaxFanSpeed: jest.fn().mockReturnValue(4),
+      hasFeature: jest.fn((feature: string) => features.has(feature)),
+      manualMode: jest.fn(),
+      maxSpeed: 4,
+      mode: 'manual',
+      petMode: jest.fn(),
+      setMode: jest.fn().mockResolvedValue(true),
+      speed: 2,
+      turnOff: jest.fn().mockResolvedValue(true),
+      turnOn: jest.fn().mockResolvedValue(true),
+      uuid: 'vital-test-unit',
+    };
+    device.petMode.mockImplementation(async () => {
+      device.mode = 'pet';
+      device.details.mode = 'pet';
+      return true;
+    });
+    device.autoMode.mockImplementation(async () => {
+      device.mode = 'auto';
+      device.details.mode = 'auto';
+      return true;
+    });
+    device.manualMode.mockImplementation(async () => {
+      device.mode = 'manual';
+      device.details.mode = 'manual';
+      return true;
+    });
+
+    const instance = new AirPurifierAccessory(platform, accessory as any, device);
+
+    return {
+      accessory,
+      device,
+      instance,
+      logger,
+      petModeHandlers,
+      primaryService,
+      stalePetService,
+      getPetModeService: () => petModeService,
+    };
+  }
+
+  it('adds the switch only when pet mode is supported', () => {
+    const supported = createHarness();
+    expect(supported.accessory.addService).toHaveBeenCalledWith(
+      'Switch',
+      'Pet Mode',
+      'pet-mode',
+    );
+
+    const unsupported = createHarness({ petCapable: false });
+    expect(unsupported.accessory.addService).not.toHaveBeenCalledWith(
+      'Switch',
+      'Pet Mode',
+      'pet-mode',
+    );
+  });
+
+  it('removes a stale cached switch when pet mode is unsupported', () => {
+    const harness = createHarness({ existingPetService: true, petCapable: false });
+
+    expect(harness.accessory.removeService).toHaveBeenCalledWith(harness.stalePetService);
+  });
+
+  it('enables pet mode, reports AUTO, and returns to auto mode', async () => {
+    const harness = createHarness();
+    const petModeService = harness.getPetModeService();
+
+    await harness.petModeHandlers.set!(true);
+
+    expect(harness.device.petMode).toHaveBeenCalledTimes(1);
+    expect(await harness.petModeHandlers.get!()).toBe(true);
+    expect(harness.primaryService.updateCharacteristic).toHaveBeenCalledWith(
+      'TargetAirPurifierState',
+      1,
+    );
+    expect(petModeService?.updateCharacteristic).toHaveBeenCalledWith('On', true);
+
+    await harness.petModeHandlers.set!(false);
+
+    expect(harness.device.autoMode).toHaveBeenCalledTimes(1);
+    expect(await harness.petModeHandlers.get!()).toBe(false);
+    expect(petModeService?.updateCharacteristic).toHaveBeenCalledWith('On', false);
+  });
+
+  it('returns to manual mode when auto mode is unavailable', async () => {
+    const harness = createHarness({ autoCapable: false });
+
+    await harness.petModeHandlers.set!(false);
+
+    expect(harness.device.manualMode).toHaveBeenCalledTimes(1);
+    expect(harness.device.autoMode).not.toHaveBeenCalled();
+  });
+
+  it('rejects failed pet mode writes so HomeKit can restore its state', async () => {
+    const harness = createHarness();
+    harness.device.petMode.mockResolvedValue(false);
+
+    await expect(harness.petModeHandlers.set!(true))
+      .rejects.toThrow('Failed to enable pet mode');
+    expect(harness.logger.error).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/utils/test-helpers.ts
+++ b/src/__tests__/utils/test-helpers.ts
@@ -15,6 +15,7 @@ const percentToKelvin = (percent: number): number => TEST_DEVICE_MIN_KELVIN + ((
 export const createMockLogger = (): jest.Mocked<Logger> => ({
   debug: jest.fn(),
   info: jest.fn(),
+  success: jest.fn(),
   warn: jest.fn(),
   error: jest.fn(),
   log: jest.fn(),

--- a/src/accessories/air-purifier.accessory.ts
+++ b/src/accessories/air-purifier.accessory.ts
@@ -644,7 +644,8 @@ export class AirPurifierAccessory extends BaseAccessory {
       // Refresh characteristics so the main service and switch stay consistent
       await this.updateDeviceSpecificStates(this.device);
     } catch (error) {
-      this.handleDeviceError('set pet mode', error);
+      await this.handleDeviceError('set pet mode', error);
+      throw error;
     }
   }
 

--- a/src/accessories/air-purifier.accessory.ts
+++ b/src/accessories/air-purifier.accessory.ts
@@ -549,11 +549,103 @@ export class AirPurifierAccessory extends BaseAccessory {
       this.accessory.removeService(existingFilterService);
     }
     
+    // Add a Pet Mode switch for devices that support it (e.g. Vital 200S / LAP-V201S)
+    this.setupPetModeSwitch();
+
     // Check and log important features for debugging
     const autoModeSupported = this.hasFeature('auto_mode');
     this.platform.log.debug(`${this.device.deviceName} (${this.device.deviceType}): Features detected:`);
     this.platform.log.debug(`  - auto_mode: ${autoModeSupported} (controls mode switch)`);
+    this.platform.log.debug(`  - pet_mode: ${this.hasFeature('pet_mode')} (controls Pet Mode switch)`);
     this.platform.log.debug(`  - filter_life: ${this.hasFeature('filter_life')} (controls filter display)`);
+  }
+
+  /**
+   * Pet mode is exposed as a dedicated Switch service because HomeKit's
+   * AirPurifier service has no native representation for it. Only added for
+   * devices whose tsvesync profile advertises the `pet_mode` feature
+   * (e.g. the Vital 200S / LAP-V201S family); any stale cached switch is
+   * removed for devices that don't support it.
+   */
+  private static readonly PET_MODE_SERVICE_NAME = 'Pet Mode';
+
+  private setupPetModeSwitch(): void {
+    const name = AirPurifierAccessory.PET_MODE_SERVICE_NAME;
+    const existing = this.accessory.getService(name);
+
+    if (!this.hasFeature('pet_mode')) {
+      if (existing) {
+        this.platform.log.debug(`${this.device.deviceName}: Removing Pet Mode switch - device does not support pet mode`);
+        this.accessory.removeService(existing);
+      }
+      return;
+    }
+
+    const petService = existing ||
+      this.accessory.addService(this.platform.Service.Switch, name, 'pet-mode');
+
+    if (!petService) {
+      this.platform.log.warn(`${this.device.deviceName}: Unable to create Pet Mode switch service`);
+      return;
+    }
+
+    petService.getCharacteristic(this.platform.Characteristic.On)
+      .onGet(this.getPetMode.bind(this))
+      .onSet(this.setPetMode.bind(this));
+
+    this.platform.log.debug(`${this.device.deviceName}: Pet Mode switch configured`);
+  }
+
+  /**
+   * Get pet mode state (on when the device's current mode is 'pet')
+   */
+  private async getPetMode(): Promise<CharacteristicValue> {
+    const extendedDevice = this.device as ExtendedVeSyncAirPurifier;
+    return (extendedDevice.mode || '').toLowerCase() === 'pet';
+  }
+
+  /**
+   * Set pet mode. Enabling switches the device into pet mode; disabling
+   * returns it to auto (pet is an automatic mode), falling back to manual
+   * for the rare device that supports pet but not auto.
+   */
+  private async setPetMode(value: CharacteristicValue): Promise<void> {
+    try {
+      const extendedDevice = this.device as ExtendedVeSyncAirPurifier;
+      let success = false;
+
+      if (value) {
+        this.platform.log.info(`Enabling pet mode for device: ${this.device.deviceName}`);
+        if (typeof extendedDevice.petMode === 'function') {
+          success = await extendedDevice.petMode();
+        } else if (typeof extendedDevice.setMode === 'function') {
+          success = await extendedDevice.setMode('pet');
+        } else {
+          throw new Error('Device API does not support pet mode');
+        }
+      } else {
+        const fallbackMode = this.hasFeature('auto_mode') ? 'auto' : 'manual';
+        this.platform.log.info(`Disabling pet mode for device: ${this.device.deviceName} (returning to ${fallbackMode})`);
+        if (fallbackMode === 'auto' && typeof extendedDevice.autoMode === 'function') {
+          success = await extendedDevice.autoMode();
+        } else if (fallbackMode === 'manual' && typeof extendedDevice.manualMode === 'function') {
+          success = await extendedDevice.manualMode();
+        } else if (typeof extendedDevice.setMode === 'function') {
+          success = await extendedDevice.setMode(fallbackMode);
+        } else {
+          throw new Error('Device API does not support mode setting operations');
+        }
+      }
+
+      if (!success) {
+        throw new Error(`Failed to ${value ? 'enable' : 'disable'} pet mode`);
+      }
+
+      // Refresh characteristics so the main service and switch stay consistent
+      await this.updateDeviceSpecificStates(this.device);
+    } catch (error) {
+      this.handleDeviceError('set pet mode', error);
+    }
   }
 
 
@@ -660,14 +752,22 @@ export class AirPurifierAccessory extends BaseAccessory {
       // Core200S always reports MANUAL mode
       targetState = 0; // MANUAL
     } else if (extendedDevice.mode) {
-      // For other devices, including Core300S, use the reported mode
-      targetState = extendedDevice.mode === 'auto' ? 1 : 0;
+      // For other devices, including Core300S, use the reported mode.
+      // Pet mode is an automatic mode, so surface it as AUTO on the main service.
+      const reportedMode = (extendedDevice.mode || '').toLowerCase();
+      targetState = (reportedMode === 'auto' || reportedMode === 'pet') ? 1 : 0;
     }
-    
+
     this.service.updateCharacteristic(
       this.platform.Characteristic.TargetAirPurifierState,
       targetState
     );
+
+    // Keep the Pet Mode switch (if present) in sync with the device mode
+    const petService = this.accessory.getService(AirPurifierAccessory.PET_MODE_SERVICE_NAME);
+    if (petService) {
+      petService.updateCharacteristic(this.platform.Characteristic.On, mode === 'pet');
+    }
 
     // Update rotation speed
     if (isOn && isTurbo) {
@@ -767,8 +867,10 @@ export class AirPurifierAccessory extends BaseAccessory {
     }
     
     const extendedDevice = this.device as ExtendedVeSyncAirPurifier;
-    const targetState = extendedDevice.mode === 'auto' ? 1 : 0;
-    
+    // Pet mode is an automatic mode, so report it as AUTO on the main service.
+    const reportedMode = (extendedDevice.mode || '').toLowerCase();
+    const targetState = (reportedMode === 'auto' || reportedMode === 'pet') ? 1 : 0;
+
     return targetState;
   }
 


### PR DESCRIPTION
## Summary

This PR adds support for "Pet" mode, which the Vital series of Air Purifiers support. The `tsvesync` library already implements `petMode()` and advertises `pet_mode` / a `pet` workMode for the LAP-V201S family. But the `AirPurifierAccessory` never actually surfaced pet mode to HomeKit — the only trace was an unused `petMode?()` stub on the device interface.

## Approach

The approach is a little funny because HomeKit only supports `Manual` and `Auto` in Air Purifier states. This adds a "Pet Mode" Switch service.

* Adds the switch **only** for pet-capable devices; removes a stale cached switch if a device doesn't support pet mode.
* `On` → `petMode()`; `Off` → `autoMode()` (pet is an automatic mode), falling back to `manualMode()` for the rare device that supports pet but not auto.
* Reports pet as AUTO on the main `TargetAirPurifierState` so the primary tile isn't misleading while pet mode is active.

<img width="603" height="1311" alt="IMG_0506" src="https://github.com/user-attachments/assets/036652ce-6ca3-4177-a1d7-5a9f21c06d40" />

