### PR TITLE
fix(air-purifier): honour Auto in batched HomeKit writes, correct Core300S speed model (#42)

### DIFF
--- a/src/__tests__/accessories/air-purifier-batch-write.test.ts
+++ b/src/__tests__/accessories/air-purifier-batch-write.test.ts
@@ -1,0 +1,531 @@
+import { API, CharacteristicValue, Logger } from 'homebridge';
+import { VeSync } from 'tsvesync';
+import { AirPurifierAccessory } from '../../accessories/air-purifier.accessory';
+import { TSVESyncPlatform } from '../../platform';
+import {
+  createMockInfoService,
+  createMockLogger,
+  createMockVeSync,
+} from '../utils/test-helpers';
+
+/**
+ * Regression tests for issue #42 - "Auto Mode not Engaging Correctly".
+ *
+ * HomeKit scenes and automations write Active, TargetAirPurifierState and
+ * RotationSpeed in a single HAP request, and HAP-NodeJS dispatches those
+ * writes concurrently. Because this accessory encodes sleep/manual/turbo into
+ * the RotationSpeed slider, every speed write is implicitly a mode write - so
+ * before the fix the speed handler raced with, and usually clobbered, an
+ * explicit AUTO written alongside it.
+ */
+describe('AirPurifierAccessory batched HomeKit writes', () => {
+  interface Handlers {
+    get?: () => Promise<CharacteristicValue>;
+    set?: (value: CharacteristicValue) => Promise<void>;
+  }
+
+  const CHARACTERISTICS = [
+    'Active', 'CurrentAirPurifierState', 'FilterChangeIndication', 'FilterLifeLevel',
+    'Manufacturer', 'Model', 'Name', 'On', 'RotationSpeed', 'SerialNumber',
+    'TargetAirPurifierState',
+  ];
+
+  function createHarness(options: { deviceType?: string; deviceStatus?: string; mode?: string } = {}) {
+    const {
+      deviceType = 'Core300S',
+      deviceStatus = 'off',
+      mode = 'manual',
+    } = options;
+
+    const logger = createMockLogger();
+    const Characteristic: Record<string, string> = {};
+    for (const c of CHARACTERISTICS) Characteristic[c] = c;
+
+    const mockAPI = {
+      hap: {
+        Characteristic,
+        Service: {
+          AccessoryInformation: 'AccessoryInformation',
+          AirPurifier: 'AirPurifier',
+          AirQualitySensor: 'AirQualitySensor',
+          FilterMaintenance: 'FilterMaintenance',
+          Switch: 'Switch',
+        },
+        uuid: { generate: jest.fn() },
+      },
+      platformAccessory: jest.fn(),
+      updatePlatformAccessories: jest.fn(),
+    } as unknown as jest.Mocked<API>;
+
+    const platform = new TSVESyncPlatform(logger as jest.Mocked<Logger>, {} as any, mockAPI);
+    (platform as any).api = mockAPI;
+    (platform as any).client = createMockVeSync() as jest.Mocked<VeSync>;
+
+    // Service mock that records the onSet/onGet handler per characteristic so
+    // the test can invoke them exactly the way HAP-NodeJS does.
+    const handlers: Record<string, Handlers> = {};
+    const chars = new Map<string, any>();
+    const getChar = (name: string) => {
+      if (!chars.has(name)) {
+        const stub: any = {
+          onSet: (fn: Handlers['set']) => { handlers[name] = { ...handlers[name], set: fn }; return stub; },
+          onGet: (fn: Handlers['get']) => { handlers[name] = { ...handlers[name], get: fn }; return stub; },
+          updateValue: () => stub,
+          setProps: (p: any) => { stub.props = p; return stub; },
+        };
+        chars.set(name, stub);
+      }
+      return chars.get(name);
+    };
+    const primaryService = {
+      getCharacteristic: jest.fn(getChar),
+      addCharacteristic: jest.fn(getChar),
+      setCharacteristic: jest.fn().mockReturnThis(),
+      testCharacteristic: jest.fn().mockReturnValue(true),
+      removeCharacteristic: jest.fn().mockReturnThis(),
+      setPrimaryService: jest.fn().mockReturnThis(),
+      updateCharacteristic: jest.fn().mockReturnThis(),
+    };
+
+    const accessory = {
+      context: {},
+      getService: jest.fn((service: any) => {
+        if (service === 'AccessoryInformation') return createMockInfoService();
+        if (service === 'AirPurifier') return primaryService;
+        return undefined;
+      }),
+      addService: jest.fn(() => primaryService),
+      removeService: jest.fn(),
+    };
+
+    const features = new Set(['fan_speed', 'filter_life', 'sleep_mode',
+      ...(deviceType === 'Core200S' ? [] : ['auto_mode'])]);
+
+    const device: any = {
+      connectionStatus: 'online',
+      details: { enabled: deviceStatus === 'on', filter_life: 80, mode, speed: 1 },
+      deviceName: 'Test Purifier',
+      deviceStatus,
+      deviceType,
+      enabled: deviceStatus === 'on',
+      filterLife: 80,
+      getDetails: jest.fn().mockResolvedValue(true),
+      getMaxFanSpeed: jest.fn().mockReturnValue(4),
+      hasFeature: jest.fn((feature: string) => features.has(feature)),
+      maxSpeed: 4,
+      uuid: 'test-purifier',
+      changeFanSpeed: jest.fn().mockResolvedValue(true),
+      setMode: jest.fn().mockResolvedValue(true),
+      autoMode: jest.fn().mockResolvedValue(true),
+      manualMode: jest.fn().mockResolvedValue(true),
+      sleepMode: jest.fn().mockResolvedValue(true),
+      turnOn: jest.fn().mockResolvedValue(true),
+      turnOff: jest.fn().mockResolvedValue(true),
+    };
+    // VeSyncFan exposes `mode` and `speed` as getter-only properties that read
+    // through to `details`. Model that exactly - a plain writable property would
+    // let the accessory "successfully" assign to them and hide real bugs.
+    Object.defineProperty(device, 'mode', { get: () => device.details.mode });
+    Object.defineProperty(device, 'speed', { get: () => device.details.speed });
+
+    device.autoMode.mockImplementation(async () => { device.details.mode = 'auto'; return true; });
+    device.manualMode.mockImplementation(async () => { device.details.mode = 'manual'; return true; });
+    device.sleepMode.mockImplementation(async () => { device.details.mode = 'sleep'; return true; });
+    device.turnOn.mockImplementation(async () => { device.deviceStatus = 'on'; device.enabled = true; return true; });
+    device.turnOff.mockImplementation(async () => { device.deviceStatus = 'off'; device.enabled = false; return true; });
+
+    new AirPurifierAccessory(platform, accessory as any, device);
+
+    /** Dispatch a batch the way HAP-NodeJS does: all writes concurrently. */
+    const writeBatch = (batch: Array<[string, number]>) =>
+      Promise.all(batch.map(([name, value]) => handlers[name].set!(value)));
+
+    return { device, handlers, primaryService, writeBatch, logger, chars };
+  }
+
+  // Core300S has three manual speeds (the library over-declares four), so with
+  // sleep on the first notch the slider is 0/25/50/75/100.
+  it('exposes a 25% step for the Core300S, with no dead top notch', () => {
+    const { chars } = createHarness();
+    expect(chars.get('RotationSpeed').props.minStep).toBe(25);
+  });
+
+  describe('an automation setting on + Auto', () => {
+    it('honours AUTO instead of the mode implied by a 60% slider', async () => {
+      const h = createHarness({ deviceStatus: 'off' });
+
+      await h.writeBatch([['Active', 1], ['TargetAirPurifierState', 1], ['RotationSpeed', 60]]);
+
+      expect(h.device.turnOn).toHaveBeenCalled();
+      expect(h.device.autoMode).toHaveBeenCalledTimes(1);
+      // The slider must not drag the device back into manual
+      expect(h.device.manualMode).not.toHaveBeenCalled();
+      expect(h.device.changeFanSpeed).not.toHaveBeenCalled();
+      expect(h.device.mode).toBe('auto');
+    });
+
+    it('honours AUTO instead of sleep for a 20% slider', async () => {
+      const h = createHarness({ deviceStatus: 'off' });
+
+      await h.writeBatch([['Active', 1], ['TargetAirPurifierState', 1], ['RotationSpeed', 20]]);
+
+      expect(h.device.autoMode).toHaveBeenCalledTimes(1);
+      expect(h.device.sleepMode).not.toHaveBeenCalled();
+      expect(h.device.mode).toBe('auto');
+    });
+
+    it('does not turn the device back off for a 0% slider', async () => {
+      const h = createHarness({ deviceStatus: 'off' });
+
+      await h.writeBatch([['Active', 1], ['TargetAirPurifierState', 1], ['RotationSpeed', 0]]);
+
+      expect(h.device.turnOn).toHaveBeenCalled();
+      expect(h.device.turnOff).not.toHaveBeenCalled();
+      expect(h.device.autoMode).toHaveBeenCalledTimes(1);
+      expect(h.device.deviceStatus).toBe('on');
+      expect(h.device.mode).toBe('auto');
+    });
+
+    it('produces the same result regardless of the order writes arrive in', async () => {
+      const h = createHarness({ deviceStatus: 'off' });
+
+      // Reverse order - the coalescer must not be order-sensitive
+      await h.writeBatch([['RotationSpeed', 60], ['TargetAirPurifierState', 1], ['Active', 1]]);
+
+      expect(h.device.mode).toBe('auto');
+      expect(h.device.changeFanSpeed).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('behaviour preserved for single-characteristic writes', () => {
+    it('still treats a lone 0% slider as "turn off"', async () => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'manual' });
+
+      await h.writeBatch([['RotationSpeed', 0]]);
+
+      expect(h.device.turnOff).toHaveBeenCalledTimes(1);
+      expect(h.device.deviceStatus).toBe('off');
+    });
+
+    it('still switches out of auto when only the slider is dragged', async () => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'auto' });
+
+      await h.writeBatch([['RotationSpeed', 75]]);
+
+      expect(h.device.manualMode).toHaveBeenCalled();
+      expect(h.device.changeFanSpeed).toHaveBeenCalledWith(2);
+    });
+
+    it('still selects sleep for the first notch when only the slider is dragged', async () => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'manual' });
+
+      await h.writeBatch([['RotationSpeed', 20]]);
+
+      expect(h.device.sleepMode).toHaveBeenCalledTimes(1);
+      expect(h.device.changeFanSpeed).not.toHaveBeenCalled();
+    });
+
+    it('still honours an explicit power off, ignoring everything else', async () => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'auto' });
+
+      await h.writeBatch([['Active', 0], ['RotationSpeed', 60]]);
+
+      expect(h.device.turnOff).toHaveBeenCalledTimes(1);
+      expect(h.device.changeFanSpeed).not.toHaveBeenCalled();
+      expect(h.device.deviceStatus).toBe('off');
+    });
+
+    it('still reaches sleep via on + MANUAL + 20%, which HomeKit reports as MANUAL', async () => {
+      const h = createHarness({ deviceStatus: 'off' });
+
+      await h.writeBatch([['Active', 1], ['TargetAirPurifierState', 0], ['RotationSpeed', 20]]);
+
+      expect(h.device.sleepMode).toHaveBeenCalledTimes(1);
+      expect(h.device.mode).toBe('sleep');
+    });
+
+    it('still applies a speed for on + MANUAL + 60%', async () => {
+      const h = createHarness({ deviceStatus: 'off' });
+
+      await h.writeBatch([['Active', 1], ['TargetAirPurifierState', 0], ['RotationSpeed', 75]]);
+
+      expect(h.device.changeFanSpeed).toHaveBeenCalledWith(2);
+      expect(h.device.mode).toBe('manual');
+    });
+  });
+
+  /**
+   * The slider implicitly changes the mode, but the accessory used to leave
+   * TargetAirPurifierState untouched and set skipNextUpdate, so the Home app
+   * kept showing "Auto" while the device had actually moved to Manual. The
+   * poll that would have corrected it has a two minute floor.
+   */
+  describe('mode is reflected back to HomeKit immediately', () => {
+    const targetStateWrites = (service: any) =>
+      service.updateCharacteristic.mock.calls.filter((c: any[]) => c[0] === 'TargetAirPurifierState');
+
+    it('reports MANUAL as soon as a slider drag leaves auto', async () => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'auto' });
+
+      await h.writeBatch([['RotationSpeed', 60]]);
+
+      expect(h.device.manualMode).toHaveBeenCalled();
+      expect(targetStateWrites(h.primaryService)).toContainEqual(['TargetAirPurifierState', 0]);
+    });
+
+    it('reports MANUAL as soon as a slider drag selects sleep', async () => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'auto' });
+
+      await h.writeBatch([['RotationSpeed', 20]]);
+
+      expect(h.device.sleepMode).toHaveBeenCalled();
+      // HomeKit has no "sleep"; sleep is reported as MANUAL
+      expect(targetStateWrites(h.primaryService)).toContainEqual(['TargetAirPurifierState', 0]);
+    });
+
+    it('still reports AUTO after an explicit auto write', async () => {
+      const h = createHarness({ deviceStatus: 'off', mode: 'manual' });
+
+      await h.writeBatch([['Active', 1], ['TargetAirPurifierState', 1], ['RotationSpeed', 60]]);
+
+      const writes = targetStateWrites(h.primaryService);
+      expect(writes[writes.length - 1]).toEqual(['TargetAirPurifierState', 1]);
+    });
+
+    it('surfaces a failed mode change instead of pushing a speed anyway', async () => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'auto' });
+      h.device.manualMode.mockResolvedValue(false);
+
+      await h.writeBatch([['RotationSpeed', 60]]);
+
+      // The speed must not be sent to a device still sitting in auto
+      expect(h.device.changeFanSpeed).not.toHaveBeenCalled();
+      expect(h.logger.error).toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * VeSync is eventually consistent: for a few seconds after a mode change
+   * getDetails() still reports the previous mode. Without a guard that stale
+   * read flips the HomeKit tile straight back - observed in both directions,
+   * auto reverting to manual and a slider drag still showing auto.
+   */
+  describe('stale API reads must not undo a commanded mode', () => {
+    const targetStateWrites = (service: any) =>
+      service.updateCharacteristic.mock.calls.filter((c: any[]) => c[0] === 'TargetAirPurifierState');
+
+    it('keeps reporting AUTO while the API still says manual', async () => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'manual' });
+      // Commanding auto succeeds, but the device keeps reporting the old mode
+      h.device.autoMode.mockImplementation(async () => true);
+
+      await h.writeBatch([['TargetAirPurifierState', 1]]);
+      expect(h.device.mode).toBe('manual'); // stale, as VeSync would report it
+
+      expect(await h.handlers.TargetAirPurifierState.get!()).toBe(1);
+    });
+
+    it('keeps reporting MANUAL while the API still says auto', async () => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'auto' });
+      // The slider moves it to manual, but the device still reports auto
+      h.device.manualMode.mockImplementation(async () => true);
+
+      await h.writeBatch([['RotationSpeed', 60]]);
+
+      // A poll lands and overwrites the cache with a stale 'auto' from the API
+      h.device.details.mode = 'auto';
+
+      expect(await h.handlers.TargetAirPurifierState.get!()).toBe(0);
+      expect(targetStateWrites(h.primaryService)).toContainEqual(['TargetAirPurifierState', 0]);
+    });
+
+    it('a poll landing mid-flight does not flip the tile back', async () => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'manual' });
+      h.device.autoMode.mockImplementation(async () => true);
+
+      await h.writeBatch([['TargetAirPurifierState', 1]]);
+      h.primaryService.updateCharacteristic.mockClear();
+
+      // Simulate the 2-minute poll arriving while VeSync still reports manual
+      await (h as any).instance?.updateDeviceSpecificStates?.(h.device);
+      const writes = targetStateWrites(h.primaryService);
+      if (writes.length) {
+        expect(writes[writes.length - 1]).toEqual(['TargetAirPurifierState', 1]);
+      }
+      expect(await h.handlers.TargetAirPurifierState.get!()).toBe(1);
+    });
+
+    it('stops overriding once the device catches up', async () => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'manual' });
+      h.device.autoMode.mockImplementation(async () => true);
+
+      await h.writeBatch([['TargetAirPurifierState', 1]]);
+      expect(await h.handlers.TargetAirPurifierState.get!()).toBe(1);
+
+      // Device catches up, then is later changed to manual in the VeSync app
+      h.device.details.mode = 'auto';
+      expect(await h.handlers.TargetAirPurifierState.get!()).toBe(1);
+      h.device.details.mode = 'manual';
+      expect(await h.handlers.TargetAirPurifierState.get!()).toBe(0);
+    });
+
+    it('expires so an out-of-band change is not masked forever', async () => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'manual' });
+      h.device.autoMode.mockImplementation(async () => true);
+
+      await h.writeBatch([['TargetAirPurifierState', 1]]);
+      expect(await h.handlers.TargetAirPurifierState.get!()).toBe(1);
+
+      // Advance past the 30s guard window
+      const realNow = Date.now;
+      Date.now = () => realNow() + 31000;
+      try {
+        expect(await h.handlers.TargetAirPurifierState.get!()).toBe(0);
+      } finally {
+        Date.now = realNow;
+      }
+    });
+  });
+
+  /**
+   * airBypass.changeFanSpeed() (the Core-series path) doesn't update the
+   * library's own cache, so device.speed stays stale until the next poll -
+   * which has a two minute floor. That made the slider snap back to the
+   * previously reported speed, and made sleep report a manual speed.
+   */
+  describe('readback after a speed change with a stale library cache', () => {
+    it('reports the speed we just set, not the stale cached one', async () => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'manual' });
+      h.device.details.speed = 3; // stale value the library keeps reporting
+      h.device.changeFanSpeed.mockResolvedValue(true);
+
+      await h.writeBatch([['RotationSpeed', 50]]); // -> speed 1
+
+      expect(h.device.changeFanSpeed).toHaveBeenCalledWith(1);
+      // Without the write-through this reported the stale speed instead
+      expect(await h.handlers.RotationSpeed.get!()).toBe(50);
+    });
+
+    it('reports the sleep notch while the device is on and in sleep', async () => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'manual' });
+      h.device.details.speed = 3; // stale
+
+      await h.writeBatch([['RotationSpeed', 25]]); // -> sleep
+
+      expect(h.device.sleepMode).toHaveBeenCalled();
+      // Previously fell through to the manual speed conversion instead
+      expect(await h.handlers.RotationSpeed.get!()).toBe(25);
+    });
+
+    it('reports 0 when the device is off', async () => {
+      const h = createHarness({ deviceStatus: 'off', mode: 'sleep' });
+      h.device.details.speed = 3;
+
+      expect(await h.handlers.RotationSpeed.get!()).toBe(0);
+    });
+  });
+
+  /**
+   * HomeKit caches characteristic metadata on the home hub. After an upgrade
+   * that changes minStep, a controller can keep sending values on the OLD grid
+   * for an unknown period - so upgrading users must still get the right speed,
+   * and must not see the slider fight them. This is the property that makes a
+   * minStep change safe to release.
+   */
+  describe('a controller using a stale slider grid', () => {
+    // Core300S: sleep + Low/Med/High, so the current grid is 25%.
+    // An un-refreshed controller still sends the old 20% grid.
+    const STALE_20_GRID: Array<[number, number | 'sleep']> = [
+      [20, 'sleep'],
+      [40, 1],
+      [60, 2],
+      [80, 3],
+      [100, 3],
+    ];
+
+    it.each(STALE_20_GRID)('maps a stale %i%% to the correct speed', async (pct, expected) => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'manual' });
+
+      await h.writeBatch([['RotationSpeed', pct as number]]);
+
+      if (expected === 'sleep') {
+        expect(h.device.sleepMode).toHaveBeenCalled();
+      } else {
+        expect(h.device.changeFanSpeed).toHaveBeenCalledWith(expected);
+      }
+    });
+
+    it.each(STALE_20_GRID)('echoes a stale %i%% straight back, so the slider does not jump', async (pct) => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'manual' });
+
+      await h.writeBatch([['RotationSpeed', pct as number]]);
+
+      expect(await h.handlers.RotationSpeed.get!()).toBe(pct);
+      const speedWrites = h.primaryService.updateCharacteristic.mock.calls
+        .filter((c: any[]) => c[0] === 'RotationSpeed');
+      expect(speedWrites[speedWrites.length - 1]).toEqual(['RotationSpeed', pct]);
+    });
+
+    it('is also correct on the current 25% grid', async () => {
+      for (const [pct, expected] of [[25, 'sleep'], [50, 1], [75, 2], [100, 3]] as const) {
+        const h = createHarness({ deviceStatus: 'on', mode: 'manual' });
+        await h.writeBatch([['RotationSpeed', pct as number]]);
+        if (expected === 'sleep') {
+          expect(h.device.sleepMode).toHaveBeenCalled();
+        } else {
+          expect(h.device.changeFanSpeed).toHaveBeenCalledWith(expected);
+        }
+        expect(await h.handlers.RotationSpeed.get!()).toBe(pct);
+      }
+    });
+  });
+
+  /**
+   * Dragging the slider produces a burst of writes spaced further apart than
+   * the coalesce window, so several batches are in flight at once. Their API
+   * calls must not interleave, or the device settles on whichever response
+   * lands last rather than the last value the user picked.
+   */
+  describe('bursts of writes are applied in order', () => {
+    it('does not interleave overlapping batches', async () => {
+      const h = createHarness({ deviceStatus: 'on', mode: 'manual' });
+
+      const inFlight: string[] = [];
+      const order: string[] = [];
+      let overlapped = false;
+      h.device.changeFanSpeed.mockImplementation(async (speed: number) => {
+        if (inFlight.length > 0) overlapped = true;
+        inFlight.push(`s${speed}`);
+        await new Promise(r => setTimeout(r, 40));
+        inFlight.pop();
+        order.push(`s${speed}`);
+        return true;
+      });
+
+      // Three drags, spaced beyond the 50ms coalesce window
+      const writes: Promise<unknown>[] = [];
+      for (const pct of [50, 75, 100]) {
+        writes.push(h.handlers.RotationSpeed.set!(pct));
+        await new Promise(r => setTimeout(r, 60));
+      }
+      await Promise.all(writes);
+
+      expect(overlapped).toBe(false);
+      expect(order).toEqual(['s1', 's2', 's3']);
+      // The device ends on the last value the user chose
+      expect(h.device.details.speed).toBe(3);
+    });
+  });
+
+  describe('Core200S', () => {
+    it('turns on without being turned straight back off by a 0% slider', async () => {
+      const h = createHarness({ deviceType: 'Core200S', deviceStatus: 'off' });
+
+      await h.writeBatch([['Active', 1], ['RotationSpeed', 0]]);
+
+      expect(h.device.turnOn).toHaveBeenCalled();
+      expect(h.device.turnOff).not.toHaveBeenCalled();
+      expect(h.device.deviceStatus).toBe('on');
+    });
+  });
+});

--- a/src/__tests__/accessories/humidifier-batch-write.test.ts
+++ b/src/__tests__/accessories/humidifier-batch-write.test.ts
@@ -1,0 +1,174 @@
+import { API, CharacteristicValue, Logger } from 'homebridge';
+import { VeSync } from 'tsvesync';
+import { HumidifierAccessory } from '../../accessories/humidifier.accessory';
+import { TSVESyncPlatform } from '../../platform';
+import {
+  createMockInfoService,
+  createMockLogger,
+  createMockVeSync,
+} from '../utils/test-helpers';
+
+/**
+ * Companion to air-purifier-batch-write.test.ts for issue #42. The humidifier
+ * has the same concurrent-write hazard: HomeKit sends Active,
+ * TargetHumidifierDehumidifierState and RotationSpeed in one HAP request, and
+ * a 0% mist slider used to turn the device straight back off.
+ */
+describe('HumidifierAccessory batched HomeKit writes', () => {
+  interface Handlers {
+    get?: () => Promise<CharacteristicValue>;
+    set?: (value: CharacteristicValue) => Promise<void>;
+  }
+
+  const CHARACTERISTICS = [
+    'Active', 'Brightness', 'CurrentHumidifierDehumidifierState', 'CurrentRelativeHumidity',
+    'CurrentTemperature', 'FilterChangeIndication', 'FilterLifeLevel', 'LockPhysicalControls',
+    'Manufacturer', 'Model', 'Name', 'On', 'RelativeHumidityHumidifierThreshold',
+    'RotationSpeed', 'SerialNumber', 'TargetHumidifierDehumidifierState', 'WaterLevel',
+  ];
+
+  function createHarness(options: { deviceStatus?: string; mode?: string } = {}) {
+    const { deviceStatus = 'off', mode = 'manual' } = options;
+
+    const logger = createMockLogger();
+    const Characteristic: Record<string, string> = {};
+    for (const c of CHARACTERISTICS) Characteristic[c] = c;
+
+    const mockAPI = {
+      hap: {
+        Characteristic,
+        Service: {
+          AccessoryInformation: 'AccessoryInformation',
+          HumidifierDehumidifier: 'HumidifierDehumidifier',
+          FilterMaintenance: 'FilterMaintenance',
+          Lightbulb: 'Lightbulb',
+          TemperatureSensor: 'TemperatureSensor',
+        },
+        uuid: { generate: jest.fn() },
+      },
+      platformAccessory: jest.fn(),
+      updatePlatformAccessories: jest.fn(),
+    } as unknown as jest.Mocked<API>;
+
+    const platform = new TSVESyncPlatform(logger as jest.Mocked<Logger>, {} as any, mockAPI);
+    (platform as any).api = mockAPI;
+    (platform as any).client = createMockVeSync() as jest.Mocked<VeSync>;
+
+    const handlers: Record<string, Handlers> = {};
+    const chars = new Map<string, any>();
+    const getChar = (name: string) => {
+      if (!chars.has(name)) {
+        const stub: any = {
+          onSet: (fn: Handlers['set']) => { handlers[name] = { ...handlers[name], set: fn }; return stub; },
+          onGet: (fn: Handlers['get']) => { handlers[name] = { ...handlers[name], get: fn }; return stub; },
+          updateValue: () => stub,
+          setProps: (p: any) => { stub.props = p; return stub; },
+        };
+        chars.set(name, stub);
+      }
+      return chars.get(name);
+    };
+    const primaryService = {
+      getCharacteristic: jest.fn(getChar),
+      addCharacteristic: jest.fn(getChar),
+      setCharacteristic: jest.fn().mockReturnThis(),
+      testCharacteristic: jest.fn().mockReturnValue(true),
+      removeCharacteristic: jest.fn().mockReturnThis(),
+      setPrimaryService: jest.fn().mockReturnThis(),
+      updateCharacteristic: jest.fn().mockReturnThis(),
+    };
+
+    const accessory = {
+      context: {},
+      getService: jest.fn((service: any) => {
+        if (service === 'AccessoryInformation') return createMockInfoService();
+        if (service === 'HumidifierDehumidifier') return primaryService;
+        return undefined;
+      }),
+      addService: jest.fn(() => primaryService),
+      removeService: jest.fn(),
+    };
+
+    const device: any = {
+      connectionStatus: 'online',
+      details: { enabled: deviceStatus === 'on', mode, humidity: 40, mist_virtual_level: 3 },
+      deviceName: 'Test Humidifier',
+      deviceStatus,
+      deviceType: 'LUH-A601S-WUSB',
+      enabled: deviceStatus === 'on',
+      mode,
+      mistLevel: 3,
+      humidity: 40,
+      uuid: 'test-humidifier',
+      getDetails: jest.fn().mockResolvedValue(true),
+      hasFeature: jest.fn(() => true),
+      changeFanSpeed: jest.fn().mockResolvedValue(true),
+      setMistLevel: jest.fn().mockResolvedValue(true),
+      setMode: jest.fn().mockResolvedValue(true),
+      setAutoMode: jest.fn().mockResolvedValue(true),
+      setManualMode: jest.fn().mockResolvedValue(true),
+      setHumidity: jest.fn().mockResolvedValue(true),
+      turnOn: jest.fn().mockResolvedValue(true),
+      turnOff: jest.fn().mockResolvedValue(true),
+    };
+    device.setAutoMode.mockImplementation(async () => { device.mode = 'auto'; device.details.mode = 'auto'; return true; });
+    device.setManualMode.mockImplementation(async () => { device.mode = 'manual'; device.details.mode = 'manual'; return true; });
+    device.turnOn.mockImplementation(async () => { device.deviceStatus = 'on'; device.enabled = true; return true; });
+    device.turnOff.mockImplementation(async () => { device.deviceStatus = 'off'; device.enabled = false; return true; });
+
+    new HumidifierAccessory(platform, accessory as any, device);
+
+    const writeBatch = (batch: Array<[string, number]>) =>
+      Promise.all(batch.map(([name, value]) => handlers[name].set!(value)));
+
+    return { device, handlers, primaryService, writeBatch, logger };
+  }
+
+  it('does not turn the device back off when a 0% slider accompanies "on"', async () => {
+    const h = createHarness({ deviceStatus: 'off' });
+
+    await h.writeBatch([['Active', 1], ['RotationSpeed', 0]]);
+
+    expect(h.device.turnOn).toHaveBeenCalled();
+    expect(h.device.turnOff).not.toHaveBeenCalled();
+    expect(h.device.deviceStatus).toBe('on');
+  });
+
+  it('honours an explicit auto request over the mist slider', async () => {
+    const h = createHarness({ deviceStatus: 'off', mode: 'manual' });
+
+    // TargetHumidifierDehumidifierState 0 == auto for this device
+    await h.writeBatch([['Active', 1], ['TargetHumidifierDehumidifierState', 0], ['RotationSpeed', 60]]);
+
+    expect(h.device.setAutoMode).toHaveBeenCalledTimes(1);
+    expect(h.device.setMistLevel).not.toHaveBeenCalled();
+    expect(h.device.mode).toBe('auto');
+  });
+
+  it('still treats a lone 0% slider as "turn off"', async () => {
+    const h = createHarness({ deviceStatus: 'on', mode: 'manual' });
+
+    await h.writeBatch([['RotationSpeed', 0]]);
+
+    expect(h.device.turnOff).toHaveBeenCalledTimes(1);
+    expect(h.device.deviceStatus).toBe('off');
+  });
+
+  it('still applies a mist level for a lone slider write', async () => {
+    const h = createHarness({ deviceStatus: 'on', mode: 'manual' });
+
+    await h.writeBatch([['RotationSpeed', 60]]);
+
+    expect(h.device.setMistLevel).toHaveBeenCalled();
+    expect(h.device.turnOff).not.toHaveBeenCalled();
+  });
+
+  it('still honours an explicit power off, ignoring everything else', async () => {
+    const h = createHarness({ deviceStatus: 'on', mode: 'auto' });
+
+    await h.writeBatch([['Active', 0], ['RotationSpeed', 60]]);
+
+    expect(h.device.turnOff).toHaveBeenCalledTimes(1);
+    expect(h.device.setMistLevel).not.toHaveBeenCalled();
+  });
+});

--- a/src/accessories/air-purifier.accessory.ts
+++ b/src/accessories/air-purifier.accessory.ts
@@ -39,7 +39,25 @@ interface ExtendedVeSyncAirPurifier extends VeSyncAirPurifier {
   };
 }
 
+/**
+ * The subset of a HomeKit write batch this accessory has to reconcile.
+ * Each field is present only if that characteristic was written.
+ */
+interface PendingWrite {
+  active?: number;
+  targetState?: number;
+  rotationSpeed?: number;
+}
+
 export class AirPurifierAccessory extends BaseAccessory {
+  /**
+   * How long to buffer characteristic writes before applying them. HAP-NodeJS
+   * dispatches every characteristic in one request within the same tick, so a
+   * short window is enough to see the whole batch; it stays far below HAP's
+   * 3s slow-write warning threshold.
+   */
+  private static readonly WRITE_COALESCE_MS = 50;
+
   private readonly capabilities: DeviceCapabilities;
   protected readonly device: VeSyncAirPurifier;
   private isAirBypassDevice: boolean;
@@ -48,6 +66,31 @@ export class AirPurifierAccessory extends BaseAccessory {
   private lastSetSpeed: number = 0; // Track the last speed we set
   private lastSetPercentage: number = 0; // Track the last percentage we set
   private skipNextUpdate: boolean = false; // Flag to skip the next update
+
+  // Coalesced write state. HomeKit scenes and automations send Active,
+  // TargetAirPurifierState and RotationSpeed in a single HAP request, and
+  // HAP-NodeJS dispatches those writes concurrently. Applying them
+  // independently makes them race and clobber each other, so they are
+  // buffered here and resolved into one intent. See resolveWrite().
+  private pendingWrite: PendingWrite | null = null;
+  private pendingWriteTimer: NodeJS.Timeout | null = null;
+  private pendingWritePromise: Promise<void> | null = null;
+  // Batches are applied one at a time. Dragging the slider produces a burst of
+  // writes spaced further apart than the coalesce window, so several batches
+  // can be in flight at once; without this their API calls interleave and the
+  // device can settle on whichever happens to land last rather than the last
+  // value the user chose.
+  private writeChain: Promise<void> = Promise.resolve();
+
+  // Tracks the last mode we commanded, to protect against stale API responses.
+  // VeSync is eventually consistent: for a few seconds after a mode change
+  // getDetails() still reports the *previous* mode, which would otherwise flip
+  // the HomeKit tile straight back (auto->manual, or manual->auto). Mirrors the
+  // guard the humidifier accessory already uses. Expires so an out-of-band
+  // change made in the VeSync app is not masked indefinitely.
+  private static readonly COMMANDED_MODE_TTL_MS = 30000;
+  private _lastCommandedMode: string | null = null;
+  private _lastCommandedModeTime = 0;
 
   constructor(
     platform: TSVESyncPlatform,
@@ -299,24 +342,67 @@ export class AirPurifierAccessory extends BaseAccessory {
     return (this.device.deviceType || '').toUpperCase().includes('CORE200S');
   }
 
+  private isCore300S(): boolean {
+    return (this.device.deviceType || '').toUpperCase().includes('CORE300S');
+  }
+
+  /**
+   * The real number of manual fan speeds, which is not always what the library
+   * advertises. tsvesync declares `levels: [1,2,3,4]` for the Core 200S and
+   * Core 300S, but both hardware families only have three manual speeds -
+   * verified against a Core300S, where changeFanSpeed(4) reports success and
+   * the device settles at 3. Trusting the declared 4 produces a dead top notch
+   * where 80% and 100% both mean speed 3.
+   */
+  private getEffectiveMaxFanSpeed(): number {
+    if (this.isCore200S() || this.isCore300S()) {
+      return 3;
+    }
+    return this.getMaxFanSpeed();
+  }
+
   /**
    * Calculate the appropriate step size for discrete speed levels
    */
   private calculateRotationSpeedStep(): number {
-    // Expose Sleep as the first notch when supported.
-    // Core 200S uses 3 manual speeds (25% step). 4-speed models use 20% step.
+    // Expose Sleep as the first notch when supported. The step is simply the
+    // width of one notch, derived from the notch count so the slider grid and
+    // the percentage->notch mapping can never disagree.
     if (this.hasFeature('sleep_mode')) {
-      if (this.hasFeature('turbo_mode')) {
-        return 20;
-      }
-      if (this.isCore200S()) return 25;
-      const max = this.getMaxFanSpeed();
-      return max >= 4 ? 20 : 25;
+      return 100 / this.getTotalNotches();
     }
     const maxSpeed = this.getMaxFanSpeed();
     if (maxSpeed === 3) return 33.33;
     if (maxSpeed === 4) return 25;
     return 1;
+  }
+
+  /**
+   * Total slider notches: sleep, each manual speed, and turbo when supported.
+   */
+  private getTotalNotches(): number {
+    const max = this.getEffectiveMaxFanSpeed();
+    return max + (this.hasFeature('turbo_mode') ? 2 : 1);
+  }
+
+  /**
+   * Map a percentage to a slider notch by which equal-width range it falls in,
+   * rather than by rounding against our own step.
+   *
+   * This has to stay correct even when the controller disagrees with us about
+   * the step. HomeKit caches characteristic metadata on the home hub, so after
+   * an upgrade that changes minStep a controller can keep sending values on the
+   * *old* grid for an unknown period. Rounding against our step maps those to
+   * the wrong speed (a 60% on an old 20% grid became Low instead of Medium);
+   * range mapping gets it right on either grid.
+   */
+  private percentageToNotch(percentage: number): number {
+    if (typeof percentage !== 'number' || isNaN(percentage) || percentage <= 0) {
+      return 0;
+    }
+    const totalNotches = this.getTotalNotches();
+    const sliceWidth = 100 / totalNotches;
+    return Math.max(1, Math.min(totalNotches, Math.ceil(percentage / sliceWidth)));
   }
 
   /**
@@ -331,7 +417,7 @@ export class AirPurifierAccessory extends BaseAccessory {
       }
       if (typeof speed !== 'number' || speed <= 0) return 0;
       const step = this.calculateRotationSpeedStep();
-      const max = this.isCore200S() ? 3 : this.getMaxFanSpeed();
+      const max = this.getEffectiveMaxFanSpeed();
       // Manual speeds occupy notches 2..(max+1)
       const notch = Math.max(2, Math.min(max + 1, speed + 1));
       return Math.min(100, notch * step);
@@ -401,11 +487,10 @@ export class AirPurifierAccessory extends BaseAccessory {
     if (this.hasFeature('sleep_mode')) {
       if (typeof percentage !== 'number') return 1;
       percentage = Math.min(100, Math.max(0, percentage));
-      const step = this.calculateRotationSpeedStep();
-      const max = this.isCore200S() ? 3 : this.getMaxFanSpeed();
+      const max = this.getEffectiveMaxFanSpeed();
       const supportsTurbo = this.hasFeature('turbo_mode');
-      const totalNotches = max + (supportsTurbo ? 2 : 1); // sleep + manual + optional turbo
-      const notch = Math.max(0, Math.min(totalNotches, Math.round(percentage / step)));
+      const totalNotches = this.getTotalNotches(); // sleep + manual + optional turbo
+      const notch = this.percentageToNotch(percentage);
       if (supportsTurbo && notch === totalNotches) {
         return max;
       }
@@ -601,7 +686,7 @@ export class AirPurifierAccessory extends BaseAccessory {
    */
   private async getPetMode(): Promise<CharacteristicValue> {
     const extendedDevice = this.device as ExtendedVeSyncAirPurifier;
-    return (extendedDevice.mode || '').toLowerCase() === 'pet';
+    return this.resolveEffectiveMode(extendedDevice.mode) === 'pet';
   }
 
   /**
@@ -640,6 +725,11 @@ export class AirPurifierAccessory extends BaseAccessory {
       if (!success) {
         throw new Error(`Failed to ${value ? 'enable' : 'disable'} pet mode`);
       }
+
+      // Hold the commanded mode against stale API reads
+      this.rememberCommandedMode(
+        value ? 'pet' : (this.hasFeature('auto_mode') ? 'auto' : 'manual')
+      );
 
       // Refresh characteristics so the main service and switch stay consistent
       await this.updateDeviceSpecificStates(this.device);
@@ -728,9 +818,11 @@ export class AirPurifierAccessory extends BaseAccessory {
    * Update device states based on the latest details
    */
   protected async updateDeviceSpecificStates(details: any): Promise<void> {
-    // Update power state (treat sleep as on for some VeSync models)
+    // Update power state (treat sleep as on for some VeSync models).
+    // Prefer the mode we last commanded - a poll that lands while VeSync is
+    // still reporting the previous mode must not flip the tile back.
     const extended = this.device as ExtendedVeSyncAirPurifier;
-    const mode = (extended.mode || details.mode || '').toLowerCase();
+    const mode = this.resolveEffectiveMode(extended.mode || details.mode || '');
     const isSleep = mode === 'sleep';
     const isTurbo = this.hasFeature('turbo_mode') && mode === 'turbo';
     const isOn = isSleep || details.enabled || details.deviceStatus === 'on';
@@ -742,21 +834,17 @@ export class AirPurifierAccessory extends BaseAccessory {
       isOn ? 2 : 0
     );
 
-    // Get the extended device to access mode information
-    const extendedDevice = this.device as ExtendedVeSyncAirPurifier;
-    
     // Update target state (MANUAL = 0, AUTO = 1)
     // Special handling for Core200S
     let targetState = 0; // Default to MANUAL
-    
+
     if (this.device.deviceType.includes('Core200S')) {
       // Core200S always reports MANUAL mode
       targetState = 0; // MANUAL
-    } else if (extendedDevice.mode) {
-      // For other devices, including Core300S, use the reported mode.
-      // Pet mode is an automatic mode, so surface it as AUTO on the main service.
-      const reportedMode = (extendedDevice.mode || '').toLowerCase();
-      targetState = (reportedMode === 'auto' || reportedMode === 'pet') ? 1 : 0;
+    } else if (mode) {
+      // For other devices, including Core300S, use the effective mode resolved
+      // above. Pet mode is an automatic mode, so surface it as AUTO.
+      targetState = this.modeToTargetState(mode);
     }
 
     this.service.updateCharacteristic(
@@ -859,6 +947,198 @@ export class AirPurifierAccessory extends BaseAccessory {
   }
 
   /**
+   * Buffer a characteristic write and return a promise that settles once the
+   * whole batch has been applied. Every characteristic in the batch shares the
+   * same promise, so HomeKit gets a success/failure per write as usual.
+   */
+  private queueWrite(key: keyof PendingWrite, value: number): Promise<void> {
+    if (!this.pendingWrite) {
+      this.pendingWrite = {};
+    }
+    this.pendingWrite[key] = value;
+
+    if (!this.pendingWritePromise) {
+      this.pendingWritePromise = new Promise<void>((resolve, reject) => {
+        this.pendingWriteTimer = setTimeout(() => {
+          const batch = this.pendingWrite ?? {};
+          this.pendingWrite = null;
+          this.pendingWritePromise = null;
+          this.pendingWriteTimer = null;
+          // Queue behind any batch still being applied so commands reach the
+          // device in the order the user made them.
+          this.writeChain = this.writeChain
+            .catch(() => undefined)
+            .then(() => this.resolveWrite(batch));
+          this.writeChain.then(resolve, reject);
+        }, AirPurifierAccessory.WRITE_COALESCE_MS);
+        // NB: deliberately not unref()'d - an unref'd timer lets the process
+        // exit before the buffered write is ever applied.
+      });
+    }
+
+    return this.pendingWritePromise;
+  }
+
+  /**
+   * Turn one buffered batch of HomeKit writes into a single device intent.
+   *
+   * The ordering rules that matter (issue #42):
+   *  - An explicit AUTO write wins over the mode implied by the speed slider.
+   *    This accessory encodes sleep/manual/turbo into RotationSpeed, so every
+   *    speed write is implicitly a mode write; without this rule an automation
+   *    that sets "on + auto + 60%" ends up in manual.
+   *  - RotationSpeed 0 only means "turn off" when the same batch didn't also
+   *    ask for the device to be on or set a mode. Otherwise "on + auto + 0%"
+   *    turns the device on and straight back off.
+   */
+  private async resolveWrite(batch: PendingWrite): Promise<void> {
+    const { active, targetState } = batch;
+    let { rotationSpeed } = batch;
+
+    this.platform.log.debug(
+      `${this.device.deviceName}: HomeKit write batch ${JSON.stringify(batch)} ` +
+      `(device reports mode=${(this.device as ExtendedVeSyncAirPurifier).mode}, ` +
+      `status=${this.device.deviceStatus}, speed=${this.device.speed})`
+    );
+
+    // An explicit power-off wins outright - nothing else in the batch matters.
+    if (active === 0) {
+      await this.applyActive(0);
+      return;
+    }
+
+    if (rotationSpeed === 0) {
+      if (active !== 1 && targetState === undefined) {
+        // Slider dragged to zero on its own - the long-standing "0% means off".
+        await this.applyActive(0);
+        return;
+      }
+      // Something else in the batch asked for the device to be on or set a
+      // mode, so the 0% slider is stale state rather than an off request.
+      this.platform.log.debug(
+        `${this.device.deviceName}: Ignoring 0% speed - batch also requested on/mode`
+      );
+      rotationSpeed = undefined;
+    }
+
+    // Power on first so the mode and speed commands land on a running device.
+    if (active === 1) {
+      await this.applyActive(1);
+    }
+
+    // Explicit AUTO beats the slider. In auto the device picks its own speed,
+    // so the requested percentage is advisory and deliberately not applied.
+    if (targetState === 1) {
+      await this.applyTargetState(1);
+      return;
+    }
+
+    // Otherwise the slider carries the mode (sleep / manual / turbo).
+    if (rotationSpeed !== undefined) {
+      await this.applyRotationSpeed(rotationSpeed);
+      return;
+    }
+
+    if (targetState === 0) {
+      await this.applyTargetState(0);
+    }
+  }
+
+  /**
+   * Write a commanded speed/mode back into the device's cached details.
+   *
+   * The bypass purifiers (Core series) don't update their own cache after a
+   * successful changeFanSpeed - unlike the bypassV2 models, which do - so
+   * device.speed stays stale until the next poll, and the poll interval has a
+   * two minute floor. That stale value makes getRotationSpeed() disagree with
+   * what we just set and snaps the slider back to the wrong notch.
+   */
+  private cacheCommandedSpeed(speed: number, mode?: string): void {
+    const device = this.device as ExtendedVeSyncAirPurifier & {
+      details?: Record<string, unknown>;
+    };
+
+    // NB: `speed` and `mode` are getter-only on VeSyncFan and read straight
+    // through to `details`. Assigning to them is a no-op in sloppy mode and a
+    // TypeError under the strict-mode build, so write to `details` instead.
+    if (device.details) {
+      device.details.speed = speed;
+      if (mode) {
+        device.details.mode = mode;
+      }
+    }
+    if (mode) {
+      this.rememberCommandedMode(mode);
+    }
+  }
+
+  /**
+   * Record a mode we just commanded so a stale API read can't undo it.
+   */
+  private rememberCommandedMode(mode: string): void {
+    this._lastCommandedMode = (mode || '').toLowerCase();
+    this._lastCommandedModeTime = Date.now();
+  }
+
+  /**
+   * Resolve the mode to report to HomeKit, preferring what we last commanded
+   * over what the device currently reports. The override is dropped as soon as
+   * the device catches up, or once it expires - so a mode changed in the VeSync
+   * app still comes through.
+   */
+  private resolveEffectiveMode(reportedMode: string): string {
+    const reported = (reportedMode || '').toLowerCase();
+
+    if (this._lastCommandedMode === null) {
+      return reported;
+    }
+
+    const elapsed = Date.now() - this._lastCommandedModeTime;
+    if (reported === this._lastCommandedMode ||
+        elapsed > AirPurifierAccessory.COMMANDED_MODE_TTL_MS) {
+      // Device caught up, or we've waited long enough - stop overriding.
+      this._lastCommandedMode = null;
+      return reported;
+    }
+
+    this.platform.log.debug(
+      `${this.device.deviceName}: Using commanded mode '${this._lastCommandedMode}' ` +
+      `instead of device-reported '${reported}'`
+    );
+    return this._lastCommandedMode;
+  }
+
+  /**
+   * Map a VeSync mode to the HomeKit TargetAirPurifierState value.
+   * Pet is an automatic mode, so it surfaces as AUTO like auto itself.
+   */
+  private modeToTargetState(mode: string): number {
+    const normalised = (mode || '').toLowerCase();
+    return (normalised === 'auto' || normalised === 'pet') ? 1 : 0;
+  }
+
+  /**
+   * Push the mode back to HomeKit immediately after we change it.
+   *
+   * The RotationSpeed slider implicitly carries a mode (sleep/manual/turbo),
+   * so dragging it can move the device out of auto. Without this the tile
+   * keeps showing the old mode until the next poll - and the poll interval has
+   * a two minute floor, so "Auto" would linger long after the device had
+   * actually switched to Manual.
+   */
+  private syncTargetStateToHomeKit(mode: string): void {
+    this.rememberCommandedMode(mode);
+    const targetState = this.modeToTargetState(mode);
+    this.service.updateCharacteristic(
+      this.platform.Characteristic.TargetAirPurifierState,
+      targetState
+    );
+    this.platform.log.debug(
+      `${this.device.deviceName}: Synced TargetAirPurifierState to ${targetState} for mode '${mode}'`
+    );
+  }
+
+  /**
    * Get target state (MANUAL = 0, AUTO = 1)
    */
   private async getTargetState(): Promise<CharacteristicValue> {
@@ -869,16 +1149,21 @@ export class AirPurifierAccessory extends BaseAccessory {
     
     const extendedDevice = this.device as ExtendedVeSyncAirPurifier;
     // Pet mode is an automatic mode, so report it as AUTO on the main service.
-    const reportedMode = (extendedDevice.mode || '').toLowerCase();
-    const targetState = (reportedMode === 'auto' || reportedMode === 'pet') ? 1 : 0;
+    // Prefer the mode we last commanded so a stale API read can't flip the tile.
+    const effectiveMode = this.resolveEffectiveMode(extendedDevice.mode);
 
-    return targetState;
+    return this.modeToTargetState(effectiveMode);
   }
 
   /**
-   * Set target state (AUTO = 0, MANUAL = 1)
+   * Set target state (MANUAL = 0, AUTO = 1). Buffered so it can be reconciled
+   * with any Active/RotationSpeed writes sent in the same HomeKit request.
    */
   private async setTargetState(value: CharacteristicValue): Promise<void> {
+    return this.queueWrite('targetState', value as number);
+  }
+
+  private async applyTargetState(value: CharacteristicValue): Promise<void> {
     try {
       const targetState = value as number;
       const extendedDevice = this.device as ExtendedVeSyncAirPurifier;
@@ -913,7 +1198,11 @@ export class AirPurifierAccessory extends BaseAccessory {
       if (!success) {
         throw new Error(`Failed to set mode to ${mode}`);
       }
-      
+
+      // Remember what we commanded so the stale-read guard holds the tile on
+      // the new mode until VeSync catches up.
+      this.rememberCommandedMode(mode);
+
       // Update device state and characteristics
       await this.updateDeviceSpecificStates(this.device);
     } catch (error) {
@@ -926,17 +1215,28 @@ export class AirPurifierAccessory extends BaseAccessory {
    */
   private async getRotationSpeed(): Promise<CharacteristicValue> {
     const extended = this.device as ExtendedVeSyncAirPurifier;
-    if (this.hasFeature('turbo_mode') && (extended.mode || '').toLowerCase() === 'turbo') {
+    const effectiveMode = this.resolveEffectiveMode(extended.mode);
+    if (this.hasFeature('turbo_mode') && effectiveMode === 'turbo') {
       return 100;
     }
-    // If device is off or speed is not defined, return 0
-    if (this.device.deviceStatus !== 'on' || 
-        this.device.speed === undefined || 
-        this.device.speed === null) {
-      // If in sleep mode, surface the first notch
-      if (this.hasFeature('sleep_mode') && (extended.mode || '').toLowerCase() === 'sleep') {
-        return this.calculateRotationSpeedStep();
+    // Sleep occupies the first notch. This has to be checked before the
+    // on/off gate below: while the device is ON the gate falls through to the
+    // speed conversion, which would report the last manual speed instead of
+    // the sleep notch.
+    if (this.hasFeature('sleep_mode') && effectiveMode === 'sleep') {
+      if (this.device.deviceStatus !== 'on') {
+        return 0;
       }
+      // Prefer the value the controller sent, so a controller on a stale grid
+      // isn't dragged to our canonical notch position.
+      return this.lastSetPercentage > 0
+        ? this.lastSetPercentage
+        : this.calculateRotationSpeedStep();
+    }
+    // If device is off or speed is not defined, return 0
+    if (this.device.deviceStatus !== 'on' ||
+        this.device.speed === undefined ||
+        this.device.speed === null) {
       return 0;
     }
     
@@ -954,35 +1254,28 @@ export class AirPurifierAccessory extends BaseAccessory {
   }
 
   /**
-   * Set rotation speed
+   * Set rotation speed. Buffered so it can be reconciled with any
+   * Active/TargetAirPurifierState writes sent in the same HomeKit request -
+   * the slider implicitly carries a mode, so it must not clobber an explicit
+   * AUTO written alongside it.
    */
   private async setRotationSpeed(value: CharacteristicValue): Promise<void> {
+    let percentage = value as number;
+    if (typeof percentage !== 'number' || isNaN(percentage)) {
+      this.platform.log.warn(`Invalid rotation speed value: ${value} for device: ${this.device.deviceName}`);
+      return;
+    }
+    percentage = Math.min(100, Math.max(0, percentage));
+    return this.queueWrite('rotationSpeed', percentage);
+  }
+
+  private async applyRotationSpeed(value: CharacteristicValue): Promise<void> {
     try {
-      // Ensure value is a valid number
-      let percentage = value as number;
-      if (isNaN(percentage) || percentage === null || percentage === undefined) {
-        this.platform.log.warn(`Invalid rotation speed value: ${value} for device: ${this.device.deviceName}`);
-        return;
-      }
-      
-      // Ensure percentage is between 0 and 100
-      percentage = Math.min(100, Math.max(0, percentage));
-      
+      // Value is already validated and clamped by setRotationSpeed()
+      const percentage = value as number;
+
       this.platform.log.debug(`Setting rotation speed to ${percentage}% for device: ${this.device.deviceName}`);
-      
-      if (percentage === 0) {
-        // Turn off the device instead of setting speed to 0
-        this.platform.log.debug(`Turning off device ${this.device.deviceName} due to 0% rotation speed`);
-        const success = await this.device.turnOff();
-        if (!success) {
-          throw new Error('Failed to turn off device');
-        }
-        // Reset tracking variables when turning off
-        this.lastSetSpeed = 0;
-        this.lastSetPercentage = 0;
-        return;
-      }
-      
+
       const extendedDevice = this.device as ExtendedVeSyncAirPurifier;
       
       // Check if device is off and turn it on first
@@ -1006,11 +1299,14 @@ export class AirPurifierAccessory extends BaseAccessory {
       
       // When using sleep-as-first-notch, map slider notches robustly by rounding
       if (this.hasFeature('sleep_mode')) {
-        const max = this.isCore200S() ? 3 : this.getMaxFanSpeed();
-        const step = this.calculateRotationSpeedStep();
+        const max = this.getEffectiveMaxFanSpeed();
         const supportsTurbo = this.hasFeature('turbo_mode');
-        const totalNotches = max + (supportsTurbo ? 2 : 1); // sleep + manual + optional turbo
-        const notch = Math.max(0, Math.min(totalNotches, Math.round(percentage / step)));
+        const totalNotches = this.getTotalNotches(); // sleep + manual + optional turbo
+        const notch = this.percentageToNotch(percentage);
+        // Echo back the value the controller actually sent rather than our own
+        // canonical notch position. If its cached step differs from ours the
+        // two are not equal, and echoing ours makes the slider visibly jump.
+        const echoPct = percentage;
         if (notch <= 1) {
           // Sleep
           this.platform.log.info(`Changing mode to sleep for device: ${this.device.deviceName}`);
@@ -1024,11 +1320,12 @@ export class AirPurifierAccessory extends BaseAccessory {
             throw new Error('Failed to set sleep mode');
           }
           // Immediate UI feedback
-          this.service.updateCharacteristic(this.platform.Characteristic.RotationSpeed, step);
+          this.service.updateCharacteristic(this.platform.Characteristic.RotationSpeed, echoPct);
           this.service.updateCharacteristic(this.platform.Characteristic.Active, 1);
           this.service.updateCharacteristic(this.platform.Characteristic.CurrentAirPurifierState, 2);
+          this.syncTargetStateToHomeKit('sleep');
           this.lastSetSpeed = 0;
-          this.lastSetPercentage = step;
+          this.lastSetPercentage = echoPct;
           this.skipNextUpdate = true;
           return;
         }
@@ -1046,6 +1343,7 @@ export class AirPurifierAccessory extends BaseAccessory {
           this.service.updateCharacteristic(this.platform.Characteristic.RotationSpeed, 100);
           this.service.updateCharacteristic(this.platform.Characteristic.Active, 1);
           this.service.updateCharacteristic(this.platform.Characteristic.CurrentAirPurifierState, 2);
+          this.syncTargetStateToHomeKit('turbo');
           this.lastSetSpeed = max;
           this.lastSetPercentage = 100;
           this.skipNextUpdate = true;
@@ -1060,17 +1358,22 @@ export class AirPurifierAccessory extends BaseAccessory {
         const modeNow = (extendedDevice.mode || '').toLowerCase();
         if (modeNow === 'auto' || modeNow === 'sleep' || (supportsTurbo && modeNow === 'turbo')) {
           this.platform.log.info(`Changing mode to manual for device: ${this.device.deviceName}`);
+          let modeOk = false;
           if (typeof extendedDevice.manualMode === 'function') {
-            await extendedDevice.manualMode();
+            modeOk = await extendedDevice.manualMode();
           } else if (typeof extendedDevice.setMode === 'function') {
-            await extendedDevice.setMode('manual');
+            modeOk = await extendedDevice.setMode('manual');
+          }
+          if (!modeOk) {
+            // Don't silently push a speed at a device still sitting in auto
+            throw new Error('Failed to set manual mode');
           }
         }
-        // Update UI early
-        const uiPct = Math.min(100, manualNotch * step);
-        this.service.updateCharacteristic(this.platform.Characteristic.RotationSpeed, uiPct);
+        // Update UI early, echoing the controller's own value
+        this.service.updateCharacteristic(this.platform.Characteristic.RotationSpeed, echoPct);
+        this.syncTargetStateToHomeKit('manual');
         this.lastSetSpeed = desiredSpeed;
-        this.lastSetPercentage = uiPct;
+        this.lastSetPercentage = echoPct;
         this.skipNextUpdate = true;
         const ok = await this.device.changeFanSpeed(desiredSpeed);
         if (!ok) {
@@ -1078,6 +1381,9 @@ export class AirPurifierAccessory extends BaseAccessory {
           this.lastSetPercentage = 0;
           throw new Error(`Failed to set speed to ${desiredSpeed}`);
         }
+        // The library leaves its cache stale for these models - fix it up so
+        // the slider doesn't snap back to the previously reported speed.
+        this.cacheCommandedSpeed(desiredSpeed, 'manual');
         return;
       }
 
@@ -1107,11 +1413,17 @@ export class AirPurifierAccessory extends BaseAccessory {
       // For devices without sleep notch, ensure manual mode if required
       const modeNow = (extendedDevice.mode || '').toLowerCase();
       if (modeNow === 'auto') {
+        let modeOk = false;
         if (typeof extendedDevice.manualMode === 'function') {
-          await extendedDevice.manualMode();
+          modeOk = await extendedDevice.manualMode();
         } else if (typeof extendedDevice.setMode === 'function') {
-          await extendedDevice.setMode('manual');
+          modeOk = await extendedDevice.setMode('manual');
         }
+        if (!modeOk) {
+          throw new Error('Failed to set manual mode');
+        }
+        // Reflect the mode change in HomeKit right away
+        this.syncTargetStateToHomeKit('manual');
       }
 
       // Convert percentage to device speed using our consistent conversion method
@@ -1140,13 +1452,15 @@ export class AirPurifierAccessory extends BaseAccessory {
       );
       
       const success = await this.device.changeFanSpeed(speed);
-      
+
       if (!success) {
         // If the API call failed, reset our tracking variables
         this.lastSetSpeed = 0;
         this.lastSetPercentage = 0;
         throw new Error(`Failed to set speed to ${speed}`);
       }
+
+      this.cacheCommandedSpeed(speed, 'manual');
       
       this.platform.log.debug(`Successfully set fan speed to ${speed} (${percentage}%) for device: ${this.device.deviceName}`);
       
@@ -1162,7 +1476,16 @@ export class AirPurifierAccessory extends BaseAccessory {
     return this.device.deviceStatus === 'on' ? 1 : 0;
   }
 
+  /**
+   * Set active state. Buffered so it can be reconciled with any
+   * RotationSpeed/TargetAirPurifierState writes sent in the same HomeKit
+   * request - notably so a 0% slider can't turn the device straight back off.
+   */
   private async setActive(value: CharacteristicValue): Promise<void> {
+    return this.queueWrite('active', value as number === 1 ? 1 : 0);
+  }
+
+  private async applyActive(value: CharacteristicValue): Promise<void> {
     try {
       const isOn = value as number === 1;
       this.platform.log.debug(`Setting device ${this.device.deviceName} to ${isOn ? 'on' : 'off'}`);

--- a/src/accessories/humidifier.accessory.ts
+++ b/src/accessories/humidifier.accessory.ts
@@ -79,6 +79,16 @@ interface ExtendedVeSyncHumidifier extends VeSyncHumidifier {
   hasFeature?(feature: string): boolean;
 }
 
+/**
+ * The subset of a HomeKit write batch this accessory has to reconcile.
+ * Each field is present only if that characteristic was written.
+ */
+interface HumidifierPendingWrite {
+  active?: number;
+  targetState?: number;
+  rotationSpeed?: number;
+}
+
 export class HumidifierAccessory extends BaseAccessory {
   protected readonly device: VeSyncHumidifier;
   private capabilities: DeviceCapabilities; // Removed readonly to allow re-initialization
@@ -99,6 +109,15 @@ export class HumidifierAccessory extends BaseAccessory {
   // Expires after 30s so out-of-band changes (VeSync app) are not masked.
   private _lastCommandedMode: string | null = null;
   private _lastCommandedModeTime: number = 0;
+
+  // Coalesced write state - see queueWrite()/resolveWrite(). HomeKit scenes and
+  // automations send Active, TargetHumidifierDehumidifierState and RotationSpeed
+  // in one HAP request and HAP-NodeJS dispatches them concurrently, so applying
+  // them independently makes them race.
+  private static readonly WRITE_COALESCE_MS = 50;
+  private pendingWrite: HumidifierPendingWrite | null = null;
+  private pendingWriteTimer: NodeJS.Timeout | null = null;
+  private pendingWritePromise: Promise<void> | null = null;
 
   constructor(
     platform: TSVESyncPlatform,
@@ -880,7 +899,92 @@ export class HumidifierAccessory extends BaseAccessory {
     return isActive ? 1 : 0;
   }
 
+  /**
+   * Buffer a characteristic write and return a promise that settles once the
+   * whole batch has been applied. Every characteristic in the batch shares the
+   * same promise, so HomeKit still gets a result per write.
+   */
+  private queueWrite(key: keyof HumidifierPendingWrite, value: number): Promise<void> {
+    if (!this.pendingWrite) {
+      this.pendingWrite = {};
+    }
+    this.pendingWrite[key] = value;
+
+    if (!this.pendingWritePromise) {
+      this.pendingWritePromise = new Promise<void>((resolve, reject) => {
+        this.pendingWriteTimer = setTimeout(() => {
+          const batch = this.pendingWrite ?? {};
+          this.pendingWrite = null;
+          this.pendingWritePromise = null;
+          this.pendingWriteTimer = null;
+          this.resolveWrite(batch).then(resolve, reject);
+        }, HumidifierAccessory.WRITE_COALESCE_MS);
+        // NB: deliberately not unref()'d - an unref'd timer lets the process
+        // exit before the buffered write is ever applied.
+      });
+    }
+
+    return this.pendingWritePromise;
+  }
+
+  /**
+   * Turn one buffered batch of HomeKit writes into a single device intent.
+   * Mirrors the air purifier rules (issue #42): an explicit auto-mode write
+   * beats the mode implied by the mist slider, and a 0% slider only means
+   * "turn off" when nothing else in the batch asked for on or a mode.
+   */
+  private async resolveWrite(batch: HumidifierPendingWrite): Promise<void> {
+    const { active, targetState } = batch;
+    let { rotationSpeed } = batch;
+
+    this.platform.log.debug(
+      `${this.device.deviceName}: Applying coalesced write ${JSON.stringify(batch)}`
+    );
+
+    if (active === 0) {
+      await this.applyActive(0);
+      return;
+    }
+
+    if (rotationSpeed === 0) {
+      if (active !== 1 && targetState === undefined) {
+        await this.applyActive(0);
+        return;
+      }
+      this.platform.log.debug(
+        `${this.device.deviceName}: Ignoring 0% mist - batch also requested on/mode`
+      );
+      rotationSpeed = undefined;
+    }
+
+    if (active === 1) {
+      await this.applyActive(1);
+    }
+
+    if (targetState !== undefined) {
+      await this.applyTargetState(targetState);
+
+      // An explicit auto request wins: in auto the device picks its own mist
+      // level, so the slider value is advisory and deliberately not applied.
+      if (this.targetStateToMode(targetState) === 'auto') {
+        return;
+      }
+    }
+
+    if (rotationSpeed !== undefined) {
+      await this.applyRotationSpeed(rotationSpeed);
+    }
+  }
+
+  /**
+   * Set active state. Buffered so it can be reconciled with any
+   * RotationSpeed/TargetHumidifierDehumidifierState writes in the same request.
+   */
   private async setActive(value: CharacteristicValue): Promise<void> {
+    return this.queueWrite('active', value as number === 1 ? 1 : 0);
+  }
+
+  private async applyActive(value: CharacteristicValue): Promise<void> {
     try {
       const isOn = value as number === 1;
       this.platform.log.debug(`Setting device ${this.device.deviceName} to ${isOn ? 'on' : 'off'}`);
@@ -999,7 +1103,15 @@ export class HumidifierAccessory extends BaseAccessory {
     }
   }
 
+  /**
+   * Set target state. Buffered so it can be reconciled with any
+   * Active/RotationSpeed writes sent in the same HomeKit request.
+   */
   private async setTargetState(value: CharacteristicValue): Promise<void> {
+    return this.queueWrite('targetState', value as number);
+  }
+
+  private async applyTargetState(value: CharacteristicValue): Promise<void> {
     try {
       // HomeKit Target State: 0 = HUMIDIFIER_OR_DEHUMIDIFIER (Auto), 1 = HUMIDIFIER, 2 = DEHUMIDIFIER
       this.platform.log.debug(`Setting target state to ${value} for device: ${this.device.deviceName}`);
@@ -1088,21 +1200,19 @@ export class HumidifierAccessory extends BaseAccessory {
     }
   }
 
+  /**
+   * Set rotation speed (mist level). Buffered so it can be reconciled with any
+   * Active/TargetHumidifierDehumidifierState writes in the same request.
+   */
   private async handleSetRotationSpeed(value: CharacteristicValue): Promise<void> {
+    return this.queueWrite('rotationSpeed', value as number);
+  }
+
+  private async applyRotationSpeed(value: CharacteristicValue): Promise<void> {
     try {
       const percentage = value as number;
       this.platform.log.debug(`Setting rotation speed to ${percentage}% for device: ${this.device.deviceName}`);
-      
-      if (percentage === 0) {
-        // Turn off the device instead of setting speed to 0
-        this.platform.log.debug(`Turning off device ${this.device.deviceName} due to 0% rotation speed`);
-        const success = await this.device.turnOff();
-        if (!success) {
-          throw new Error('Failed to turn off device');
-        }
-        return;
-      }
-  
+
       // Convert percentage to mist level based on device type
       let speed: number;
       if (this.isHumidDual200S) {


### PR DESCRIPTION
Fixes #42.

Setting a Vital 200S to Auto from an Apple Home automation lands in manual, sleep, or off depending purely on the slider position. Investigating that surfaced several related defects in the air purifier's write and readback paths — all reproduced live against a Core 300S, two Core 200S and an LUH-A601S humidifier.

## 1. Batched writes raced (the reported bug)

HomeKit scenes and automations write `Active`, `TargetAirPurifierState` and `RotationSpeed` in a **single** HAP request, and HAP-NodeJS dispatches those writes **concurrently** (`Accessory.js`, the `_loop_2` dispatch — it calls `handleCharacteristicWrite(...).then(...)` per characteristic without awaiting).

Because this accessory encodes sleep/manual/turbo into the `RotationSpeed` slider, every speed write is implicitly a *mode* write. So the speed handler raced the explicit AUTO alongside it, and usually won:

| Slider in automation | Result before |
|---|---|
| 0% | turns on, then straight back off |
| 20% | sleep |
| 40–100% | manual |

Which matches the report exactly. Reproduced live, then confirmed as a genuine race — one run of the 20% case happened to land on auto, so the reporter's consistent "sleep" is timing, not determinism.

Writes are now buffered and resolved into one intent:

- an explicit **AUTO beats the mode implied by the slider** — in auto the device picks its own speed, so the percentage is advisory
- `RotationSpeed 0` only means "turn off" when nothing else in the batch asked for on or a mode
- an explicit `Active 0` still wins outright

Batches are applied **one at a time**. Dragging the slider produces a burst of writes spaced further apart than the coalesce window, so several batches are in flight at once; un-serialised, their API calls interleave and the device settles on whichever response lands last rather than the last value the user chose.

The humidifier had the same hazard — a 0% mist slider arriving with `Active 1` turned it straight back off — and gets the same treatment.

## 2. Mode changes were never reported back

A slider drag can move the device out of auto, but `TargetAirPurifierState` was never pushed, so the tile kept showing "Auto" while the device was in Manual — until the next poll, and the poll interval has a **two minute floor** (`platform.ts:154`). Confirmed from a live log: the plugin issued `Changing mode to manual` + `Changing fan speed to 1` and the device reported `manual`, while the Home app still showed Auto.

Failed `manualMode()` calls were also silently discarded, so a speed could be sent to a device still sitting in auto. That now throws.

## 3. Speed readback used a stale cache

`airBypass.changeFanSpeed()` doesn't update the library's own cache (the bypassV2 path does), so `device.speed` stayed stale until the next poll. Drag to 40%, read back 80% — the slider snaps. Sleep was additionally gated on the device being *off*, so while running it reported the last manual speed instead of the sleep notch.

Fixed upstream in mickgiles/tsvesync#6; the plugin-side write-through stays for compatibility with older library versions.

## 4. Core 300S has three speeds, not four

tsvesync declares `levels: [1,2,3,4]` for the Core 300S, but the hardware is Low/Med/High plus Sleep. `changeFanSpeed(4)` reports success and the device settles at 3, so the top two slider notches were identical — a dead position. The code already hard-coded this correction for the Core 200S and never extended it to the 300S, which is identical hardware.

The slider is now `0/25/50/75/100` mapped 1:1 to off/Sleep/Low/Med/High.

### Making that safe to upgrade into

Changing `minStep` is not free: HomeKit caches characteristic metadata on the **home hub**, and a controller can keep sending values on the old 20% grid for an unknown period after upgrading. The config-number bump is the only in-protocol signal and controllers act on it lazily.

Rounding a stale percentage against our own step produced genuinely **wrong speeds**, not just cosmetic flicker:

```
 60% -> Low     (should be Medium)
 80% -> Medium  (should be High)
```

So percentages are now mapped by **which range they fall into** rather than by rounding against our step, and the **controller's own value is echoed back** so the slider doesn't fight it. Verified live on both grids:

| Sent | Stale 20% grid | Current 25% grid |
|---|---|---|
| 20 / 25% | Sleep ✓ | Sleep ✓ |
| 40 / 50% | Low ✓ | Low ✓ |
| 60 / 75% | Medium ✓ | Medium ✓ |
| 80 / 100% | High ✓ | High ✓ |

Upgrading users get correct speeds immediately; only the tick marks need the hub to catch up.

**Release note needed:** the Core 300S slider goes from five positions to four. If doubled tick marks appear after upgrading, removing the single cached accessory in Homebridge settings and letting it be rediscovered clears it (confirmed working); restarting the home hub also does. Fan speeds are correct either way.

## Testing

174 tests, up from 133. The new suites are genuine regressions — reverting the source makes them fail, and the ones that still pass are exactly the "behaviour preserved" cases.

Covered: the batch-write intent rules; single-characteristic behaviour preserved (lone 0% still turns off, lone slider drag still leaves auto); immediate mode reporting; stale-read guard incl. expiry; readback with a stale library cache; **table-driven stale-grid correctness**, which is the property that makes the `minStep` change safe to release; and burst ordering.

Test mocks model `mode`/`speed` as getter-only properties reading through `details`, matching `VeSyncFan`. That's deliberate — a plain writable property let a broken fix "succeed" against the mock while throwing under the strict-mode build.

Also verified live end-to-end against the deployed build on real hardware, including every scenario in the report plus the non-auto paths, and lint is unchanged at 13 pre-existing problems.

## Not included

Reporting `FirmwareRevision` (currently unset) came up during investigation as a possible cache-bust lever. It doesn't work for that — the hash omits characteristic *values* — but it's a reasonable small improvement on its own and I left it out to keep this scoped.