### PR TITLE
fix(names): sanitize HomeKit-facing names to HAP's legal charset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.6.1 (2026-07-27)
+
+### Fixed
+- **HomeKit Name Warnings Eliminated** ([#46](https://github.com/mickgiles/homebridge-tsvesync/issues/46)): VeSync factory device names like "OasisMist™ 4.5L" contain symbols HomeKit's Name characteristic does not allow, so HAP warned on every startup ("invalid 'Name' characteristic") and iOS could refuse to add the accessory. Every HomeKit-facing name — accessory display names, service Name characteristics, and the air-quality sensor name — is now reduced to HomeKit's legal charset (letters, numbers, spaces, apostrophes, commas, periods, hyphens, starting and ending with a letter or number), with unicode letters preserved. Existing installs are repaired automatically: cached accessories with an invalid name are rewritten on restore, no re-pairing needed. Raw device names are untouched for logs and VeSync API calls, and accessory identity comes from the device id, so rooms, scenes, and automations are unaffected. Renaming in the Home app is also unaffected — HomeKit keeps its own labels.
+
 ## 1.6.0 (2026-07-27)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-tsvesync",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Homebridge plugin for VeSync devices including Levoit air purifiers, humidifiers, and Etekcity smart outlets",
   "main": "dist/index.js",
   "scripts": {

--- a/src/__tests__/accessory-name-sanitize.test.ts
+++ b/src/__tests__/accessory-name-sanitize.test.ts
@@ -1,0 +1,279 @@
+jest.mock('../utils/device-factory');
+
+import { API, CharacteristicValue, Logger, Service as ServiceType, Characteristic as CharacteristicType } from 'homebridge';
+import { VeSync } from 'tsvesync';
+import { TSVESyncPlatform } from '../platform';
+import { AirPurifierAccessory } from '../accessories/air-purifier.accessory';
+import { DeviceFactory } from '../utils/device-factory';
+import { BaseAccessory } from '../accessories/base.accessory';
+import {
+  createMockInfoService,
+  createMockLogger,
+  createMockService,
+  createMockVeSync,
+} from './utils/test-helpers';
+
+const mockDeviceFactory = jest.mocked(DeviceFactory);
+
+/**
+ * Regression tests for issue #46: VeSync factory names like "OasisMist™ 4.5L"
+ * violate HomeKit's Name charset and trigger HAP warnings (and can block
+ * pairing). Every HomeKit-facing name must be sanitized; raw names stay in
+ * logs and API calls.
+ */
+describe('HomeKit name sanitization (issue #46)', () => {
+  describe('platform accessory creation', () => {
+    let platform: TSVESyncPlatform;
+    let mockAPI: jest.Mocked<API>;
+    let mockVeSync: jest.Mocked<VeSync>;
+
+    beforeEach(() => {
+      jest.useFakeTimers({ advanceTimers: true });
+
+      mockVeSync = createMockVeSync();
+      mockAPI = {
+        version: 2.0,
+        serverVersion: '1.0.0',
+        user: {
+          configPath: jest.fn(),
+          storagePath: jest.fn().mockReturnValue('/tmp'),
+          persistPath: jest.fn(),
+        },
+        hapLegacyTypes: {},
+        platformAccessory: jest.fn().mockImplementation((name, uuid, category) => ({
+          UUID: uuid,
+          displayName: name,
+          category,
+          context: {},
+          addService: jest.fn(),
+          removeService: jest.fn(),
+          getService: jest.fn(),
+          getServiceById: jest.fn(),
+        })),
+        versionGreaterOrEqual: jest.fn(),
+        registerPlatformAccessories: jest.fn(),
+        unregisterPlatformAccessories: jest.fn(),
+        updatePlatformAccessories: jest.fn(),
+        on: jest.fn(),
+        hap: {
+          Service: {
+            AccessoryInformation: jest.fn(),
+          } as unknown as typeof ServiceType,
+          Characteristic: {
+            Name: 'Name',
+            Manufacturer: 'Manufacturer',
+            Model: 'Model',
+            SerialNumber: 'SerialNumber',
+          } as unknown as typeof CharacteristicType,
+          Categories: {
+            SENSOR: 10,
+          },
+          uuid: {
+            generate: jest.fn().mockImplementation((id) => `test-uuid-${id}`),
+          },
+        },
+      } as unknown as jest.Mocked<API>;
+
+      platform = new TSVESyncPlatform(
+        createMockLogger() as jest.Mocked<Logger>,
+        { name: 'Test Platform', username: 'u', password: 'p', platform: 'TSVESyncPlatform' } as any,
+        mockAPI
+      );
+      (platform as any).client = mockVeSync;
+
+      const stubAccessory = {
+        initialize: jest.fn().mockResolvedValue(undefined),
+        syncDeviceState: jest.fn().mockResolvedValue(undefined),
+        applyUpdatedDeviceState: jest.fn(),
+      } as unknown as BaseAccessory;
+
+      mockDeviceFactory.getAccessoryCategory.mockReturnValue(0 as any);
+      mockDeviceFactory.isAirPurifier.mockImplementation((deviceType: string) => deviceType.toUpperCase().includes('CORE'));
+      mockDeviceFactory.createAccessory.mockReturnValue(stubAccessory);
+      mockDeviceFactory.createAQSensorAccessory.mockReturnValue(stubAccessory);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    function mockDevice(overrides: Record<string, unknown> = {}) {
+      return {
+        deviceName: 'OasisMist™ 4.5L',
+        deviceType: 'LUH-M101S-WUS',
+        cid: 'cid-oasis',
+        uuid: 'uuid-oasis',
+        deviceStatus: 'on',
+        deviceRegion: 'US',
+        configModule: 'VeSyncHumid',
+        macId: '00:11:22:33:44:55',
+        deviceCategory: 'fan',
+        connectionStatus: 'online',
+        details: {},
+        config: {},
+        ...overrides,
+      };
+    }
+
+    it('creates new accessories with a sanitized display name', async () => {
+      mockVeSync.fans = [mockDevice() as any];
+
+      await platform.discoverDevices();
+
+      expect(mockAPI.platformAccessory).toHaveBeenCalledWith(
+        'OasisMist 4.5L',
+        expect.any(String),
+        expect.anything()
+      );
+    });
+
+    it('creates AQ sensor accessories with a sanitized display name', async () => {
+      mockVeSync.fans = [mockDevice({
+        deviceName: 'Core 400S™',
+        deviceType: 'Core400S',
+        cid: 'cid-core',
+        uuid: 'uuid-core',
+        hasFeature: (feature: string) => feature === 'air_quality',
+      }) as any];
+
+      await platform.discoverDevices();
+
+      expect(mockAPI.platformAccessory).toHaveBeenCalledWith(
+        'Core 400S Air Quality',
+        expect.any(String),
+        10
+      );
+    });
+
+    it('repairs an invalid cached accessory name on restore', () => {
+      const infoService = { updateCharacteristic: jest.fn() };
+      const cached: any = {
+        UUID: 'cached-uuid',
+        displayName: 'OasisMist™ 4.5L',
+        context: {},
+        getService: jest.fn().mockReturnValue(infoService),
+      };
+
+      platform.configureAccessory(cached);
+
+      expect(cached.displayName).toBe('OasisMist 4.5L');
+      expect(infoService.updateCharacteristic).toHaveBeenCalledWith('Name', 'OasisMist 4.5L');
+      expect(mockAPI.updatePlatformAccessories).toHaveBeenCalledWith([cached]);
+    });
+
+    it('leaves valid cached accessory names untouched', () => {
+      const cached: any = {
+        UUID: 'cached-uuid',
+        displayName: 'Bedroom Air Purifier',
+        context: {},
+        getService: jest.fn(),
+      };
+
+      platform.configureAccessory(cached);
+
+      expect(cached.displayName).toBe('Bedroom Air Purifier');
+      expect(cached.getService).not.toHaveBeenCalled();
+      expect(mockAPI.updatePlatformAccessories).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('accessory Name characteristic', () => {
+    interface Handlers {
+      get?: () => Promise<CharacteristicValue>;
+      set?: (value: CharacteristicValue) => Promise<void>;
+    }
+
+    it('serves the sanitized name through the Name characteristic', async () => {
+      const logger = createMockLogger();
+      const mockAPI = {
+        hap: {
+          Characteristic: {
+            Active: 'Active',
+            CurrentAirPurifierState: 'CurrentAirPurifierState',
+            FilterChangeIndication: 'FilterChangeIndication',
+            FilterLifeLevel: 'FilterLifeLevel',
+            Manufacturer: 'Manufacturer',
+            Model: 'Model',
+            Name: 'Name',
+            On: 'On',
+            RotationSpeed: 'RotationSpeed',
+            SerialNumber: 'SerialNumber',
+            TargetAirPurifierState: 'TargetAirPurifierState',
+          },
+          Service: {
+            AccessoryInformation: 'AccessoryInformation',
+            AirPurifier: 'AirPurifier',
+            AirQualitySensor: 'AirQualitySensor',
+            FilterMaintenance: 'FilterMaintenance',
+            Switch: 'Switch',
+          },
+          uuid: { generate: jest.fn() },
+        },
+        platformAccessory: jest.fn(),
+        updatePlatformAccessories: jest.fn(),
+      } as unknown as jest.Mocked<API>;
+      const platform = new TSVESyncPlatform(logger as jest.Mocked<Logger>, {} as any, mockAPI);
+      (platform as any).api = mockAPI;
+      (platform as any).client = createMockVeSync() as jest.Mocked<VeSync>;
+
+      const handlers: Record<string, Handlers> = {};
+      const chars = new Map<string, any>();
+      const getChar = (name: string) => {
+        if (!chars.has(name)) {
+          const stub: any = {
+            onSet: (fn: Handlers['set']) => { handlers[name] = { ...handlers[name], set: fn }; return stub; },
+            onGet: (fn: Handlers['get']) => { handlers[name] = { ...handlers[name], get: fn }; return stub; },
+            updateValue: () => stub,
+            setProps: () => stub,
+          };
+          chars.set(name, stub);
+        }
+        return chars.get(name);
+      };
+      const primaryService = {
+        ...createMockService(),
+        getCharacteristic: jest.fn((c: any) => getChar(String(c))),
+        updateCharacteristic: jest.fn().mockReturnThis(),
+      };
+      const infoService = createMockInfoService();
+      const accessory = {
+        context: {},
+        getService: jest.fn((service: any) => {
+          if (service === 'AccessoryInformation') return infoService;
+          if (service === 'AirPurifier') return primaryService;
+          return undefined;
+        }),
+        addService: jest.fn(() => primaryService),
+        removeService: jest.fn(),
+      };
+
+      const device: any = {
+        changeFanSpeed: jest.fn().mockResolvedValue(true),
+        connectionStatus: 'online',
+        details: { enabled: true, filter_life: 80, mode: 'manual', speed: 2 },
+        deviceName: 'Levoit™ Purifier®',
+        deviceStatus: 'on',
+        deviceType: 'Core300S',
+        enabled: true,
+        filterLife: 80,
+        getDetails: jest.fn().mockResolvedValue(true),
+        getMaxFanSpeed: jest.fn().mockReturnValue(3),
+        hasFeature: jest.fn().mockReturnValue(false),
+        maxSpeed: 3,
+        mode: 'manual',
+        setMode: jest.fn().mockResolvedValue(true),
+        speed: 2,
+        turnOff: jest.fn().mockResolvedValue(true),
+        turnOn: jest.fn().mockResolvedValue(true),
+        uuid: 'purifier-uuid',
+      };
+
+      new AirPurifierAccessory(platform, accessory as any, device);
+
+      expect(handlers.Name?.get).toBeDefined();
+      expect(await handlers.Name.get!()).toBe('Levoit Purifier');
+      // The device object itself must keep the raw name for API calls
+      expect(device.deviceName).toBe('Levoit™ Purifier®');
+    });
+  });
+});

--- a/src/__tests__/utils/sanitize-name.test.ts
+++ b/src/__tests__/utils/sanitize-name.test.ts
@@ -1,0 +1,56 @@
+import {
+  DEFAULT_ACCESSORY_NAME,
+  isValidHomeKitName,
+  sanitizeDeviceName,
+} from '../../utils/sanitize-name';
+
+describe('sanitizeDeviceName', () => {
+  it.each([
+    // [input, expected] - names needing repair
+    ['OasisMist™ 4.5L', 'OasisMist 4.5L'],
+    ['OasisMist® 4.5L', 'OasisMist 4.5L'],
+    ['Fan 💨', 'Fan'],
+    ['A™B', 'A B'],
+    ['  - Bedroom -  ', 'Bedroom'],
+    ['Fan.', 'Fan'],
+    ['"Office" Purifier', 'Office Purifier'],
+    ['Fan   with   spaces', 'Fan with spaces'],
+    ['\'Quoted\'', 'Quoted'],
+  ])('sanitizes %j to %j', (input, expected) => {
+    expect(sanitizeDeviceName(input)).toBe(expected);
+  });
+
+  it.each([
+    // Already-valid names must pass through untouched
+    ['Core 300S Series'],
+    ["Mick's Fan, No. 2 - Office"],
+    ['Büro Lüfter'],
+    ['加湿器'],
+    ['Bedroom Air Purifier'],
+  ])('leaves valid name %j unchanged', (input) => {
+    expect(sanitizeDeviceName(input)).toBe(input);
+  });
+
+  it('falls back when nothing usable remains', () => {
+    expect(sanitizeDeviceName('™®')).toBe(DEFAULT_ACCESSORY_NAME);
+    expect(sanitizeDeviceName('   ')).toBe(DEFAULT_ACCESSORY_NAME);
+    expect(sanitizeDeviceName('')).toBe(DEFAULT_ACCESSORY_NAME);
+    expect(sanitizeDeviceName(undefined as unknown as string)).toBe(DEFAULT_ACCESSORY_NAME);
+  });
+
+  it('honours a custom fallback', () => {
+    expect(sanitizeDeviceName('🎉', 'Backup Name')).toBe('Backup Name');
+  });
+});
+
+describe('isValidHomeKitName', () => {
+  it.each([
+    ['Core 300S Series', true],
+    ['OasisMist™ 4.5L', false],
+    ['Fan.', false],
+    ['', false],
+    ["Mick's Fan", true],
+  ])('%j -> %s', (input, expected) => {
+    expect(isValidHomeKitName(input)).toBe(expected);
+  });
+});

--- a/src/accessories/air-purifier.accessory.ts
+++ b/src/accessories/air-purifier.accessory.ts
@@ -620,7 +620,7 @@ export class AirPurifierAccessory extends BaseAccessory {
     // Add Name characteristic
     this.setupCharacteristic(
       this.platform.Characteristic.Name,
-      async () => this.device.deviceName
+      async () => this.sanitizedDeviceName
     );
     
     // Air quality sensors are now separate accessories

--- a/src/accessories/air-quality-sensor.accessory.ts
+++ b/src/accessories/air-quality-sensor.accessory.ts
@@ -32,7 +32,7 @@ export class AirQualitySensorAccessory extends BaseAccessory {
       this.accessory.addService(this.platform.Service.AirQualitySensor);
 
     // Set the service name
-    this.service.setCharacteristic(this.platform.Characteristic.Name, `${device.deviceName} Air Quality`);
+    this.service.setCharacteristic(this.platform.Characteristic.Name, `${this.sanitizedDeviceName} Air Quality`);
 
     // Configure the Air Quality characteristic
     this.service.getCharacteristic(this.platform.Characteristic.AirQuality)

--- a/src/accessories/base.accessory.ts
+++ b/src/accessories/base.accessory.ts
@@ -3,6 +3,7 @@ import { TSVESyncPlatform } from '../platform';
 import { DeviceCapabilities, VeSyncDeviceWithPower } from '../types/device.types';
 import { RetryManager } from '../utils/retry';
 import { LogContext, PluginLogger } from '../utils/logger';
+import { sanitizeDeviceName } from '../utils/sanitize-name';
 
 export abstract class BaseAccessory {
   protected service!: Service;
@@ -79,6 +80,14 @@ export abstract class BaseAccessory {
    * Get device capabilities
    */
   protected abstract getDeviceCapabilities(): DeviceCapabilities;
+
+  /**
+   * The device name reduced to HomeKit's legal Name charset. Use this for
+   * every HomeKit-facing name; keep the raw deviceName for logs and API calls.
+   */
+  protected get sanitizedDeviceName(): string {
+    return sanitizeDeviceName(this.device.deviceName);
+  }
 
   /**
    * Get the device type for polling configuration

--- a/src/accessories/fan.accessory.ts
+++ b/src/accessories/fan.accessory.ts
@@ -104,7 +104,7 @@ export class FanAccessory extends BaseAccessory {
     // Add Name characteristic
     this.setupCharacteristic(
       this.platform.Characteristic.Name,
-      async () => this.device.deviceName
+      async () => this.sanitizedDeviceName
     );
   }
 

--- a/src/accessories/humidifier.accessory.ts
+++ b/src/accessories/humidifier.accessory.ts
@@ -388,7 +388,7 @@ export class HumidifierAccessory extends BaseAccessory {
     // Add Name characteristic
     this.setupCharacteristic(
       this.platform.Characteristic.Name,
-      async () => this.device.deviceName
+      async () => this.sanitizedDeviceName
     );
 
     // CurrentRelativeHumidity getter
@@ -484,7 +484,7 @@ export class HumidifierAccessory extends BaseAccessory {
     // Set name for the temperature sensor
     this.setupCharacteristic(
       this.platform.Characteristic.Name,
-      async () => `${this.device.deviceName} Temperature`,
+      async () => `${this.sanitizedDeviceName} Temperature`,
       undefined,
       undefined,
       this.temperatureService
@@ -536,7 +536,7 @@ export class HumidifierAccessory extends BaseAccessory {
     // Set name for the filter service
     this.setupCharacteristic(
       this.platform.Characteristic.Name,
-      async () => `${this.device.deviceName} Filter`,
+      async () => `${this.sanitizedDeviceName} Filter`,
       undefined,
       undefined,
       this.filterService

--- a/src/accessories/light.accessory.ts
+++ b/src/accessories/light.accessory.ts
@@ -80,7 +80,7 @@ export class LightAccessory extends BaseAccessory {
     // Add Name characteristic
     this.setupCharacteristic(
       this.platform.Characteristic.Name,
-      async () => this.device.deviceName
+      async () => this.sanitizedDeviceName
     );
 
     if (this.isDimmerDevice && this.supportsIndicatorLight()) {

--- a/src/accessories/outlet.accessory.ts
+++ b/src/accessories/outlet.accessory.ts
@@ -62,7 +62,7 @@ export class OutletAccessory extends BaseAccessory {
     // Add Name characteristic
     this.setupCharacteristic(
       this.platform.Characteristic.Name,
-      async () => this.device.deviceName
+      async () => this.sanitizedDeviceName
     );
   }
 

--- a/src/accessories/switch.accessory.ts
+++ b/src/accessories/switch.accessory.ts
@@ -30,7 +30,7 @@ export class SwitchAccessory extends BaseAccessory {
     // Add Name characteristic
     this.service.setCharacteristic(
       this.platform.Characteristic.Name,
-      this.device.deviceName
+      this.sanitizedDeviceName
     );
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -7,6 +7,7 @@ import { PluginLogger } from './utils/logger';
 import { createRateLimitedVeSync } from './utils/api-proxy';
 import { PlatformConfig as TSVESyncPlatformConfig } from './types/device.types';
 import { FileSessionStore, PluginSession, decodeJwtTimestampsLocal } from './utils/session-store';
+import { sanitizeDeviceName } from './utils/sanitize-name';
 
 /**
  * HomebridgePlatform
@@ -243,7 +244,28 @@ export class TSVESyncPlatform implements DynamicPlatformPlugin {
    */
   configureAccessory(accessory: PlatformAccessory) {
     this.logger.info('Loading accessory from cache:', accessory.displayName);
+    this.repairAccessoryName(accessory);
     this.accessories.push(accessory);
+  }
+
+  /**
+   * Accessories cached before name sanitization existed may carry a name
+   * HomeKit rejects (e.g. "OasisMist™ 4.5L"). Rewrite the display name and
+   * the AccessoryInformation Name so HAP stops warning on every startup.
+   * The Home app keeps its own user-assigned label, so this never renames
+   * anything the user sees.
+   */
+  private repairAccessoryName(accessory: PlatformAccessory): void {
+    const sanitized = sanitizeDeviceName(accessory.displayName);
+    if (sanitized === accessory.displayName) {
+      return;
+    }
+
+    this.logger.info(`Sanitizing cached accessory name "${accessory.displayName}" -> "${sanitized}"`);
+    accessory.displayName = sanitized;
+    accessory.getService(this.Service.AccessoryInformation)
+      ?.updateCharacteristic(this.Characteristic.Name, sanitized);
+    this.api.updatePlatformAccessories([accessory]);
   }
 
   /**
@@ -651,7 +673,7 @@ export class TSVESyncPlatform implements DynamicPlatformPlugin {
           
           // Create the accessory
           accessory = new this.api.platformAccessory(
-            device.deviceName,
+            sanitizeDeviceName(device.deviceName),
             uuid,
             DeviceFactory.getAccessoryCategory(device.deviceType)
           );
@@ -696,7 +718,7 @@ export class TSVESyncPlatform implements DynamicPlatformPlugin {
             
             // Create the AQ sensor accessory with SENSOR category
             aqAccessory = new this.api.platformAccessory(
-              device.deviceName + ' Air Quality',
+              sanitizeDeviceName(device.deviceName) + ' Air Quality',
               aqUuid,
               this.api.hap.Categories.SENSOR
             );

--- a/src/utils/sanitize-name.ts
+++ b/src/utils/sanitize-name.ts
@@ -1,0 +1,35 @@
+/**
+ * HomeKit restricts the Name characteristic (HAP-NodeJS warns and iOS can
+ * refuse to add the accessory otherwise): only letters, numbers, spaces,
+ * apostrophes, commas, periods, and hyphens are allowed, and the name must
+ * start and end with a letter or number. VeSync factory device names often
+ * violate this (e.g. "OasisMist™ 4.5L").
+ *
+ * Unicode letters and digits are permitted, so accented names survive intact.
+ */
+
+const DISALLOWED_CHARS = /[^\p{L}\p{N} ',.-]/gu;
+const LEADING_TRAILING_JUNK = /^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu;
+
+export const DEFAULT_ACCESSORY_NAME = 'VeSync Device';
+
+/**
+ * Returns true when a name already satisfies HomeKit's Name rules.
+ */
+export function isValidHomeKitName(name: string): boolean {
+  return name.length > 0 && name === sanitizeDeviceName(name, name);
+}
+
+/**
+ * Reduce an arbitrary device name to a HomeKit-legal one:
+ * strip disallowed symbols, collapse whitespace, and trim leading/trailing
+ * non-alphanumerics. Falls back when nothing usable remains.
+ */
+export function sanitizeDeviceName(name: string, fallback = DEFAULT_ACCESSORY_NAME): string {
+  const cleaned = (name ?? '')
+    .replace(DISALLOWED_CHARS, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(LEADING_TRAILING_JUNK, '');
+  return cleaned.length > 0 ? cleaned : fallback;
+}


### PR DESCRIPTION
## Summary

Fixes #46. VeSync factory device names like `OasisMist™ 4.5L` violate HomeKit's Name characteristic rules (letters, numbers, spaces, apostrophes, commas, periods, hyphens; must start and end with a letter or number). HAP-NodeJS warns on every startup and iOS can refuse to add the accessory.

**Every HomeKit-facing name now passes through `sanitizeDeviceName()`** (`src/utils/sanitize-name.ts`):

- Accessory display names at creation (`platform.ts`, both the main accessory and the AQ sensor)
- Every service `Name` characteristic (purifier, humidifier + its Temperature/Filter sub-services, fan, outlet, switch, light, AQ sensor) via a shared `sanitizedDeviceName` getter on `BaseAccessory`
- **Existing installs are repaired automatically**: cached accessories with an invalid name are rewritten on restore (`displayName` + AccessoryInformation `Name`) — the reporter's warning disappears on next restart with no re-pairing

Deliberately untouched:
- Raw `deviceName` stays as-is for logs and VeSync API calls
- Accessory UUIDs derive from the device `cid`, so rooms, scenes, and automations are unaffected
- Unicode letters are preserved (`Büro Lüfter`, `加湿器` stay intact); only illegal symbols are stripped
- Home-app user labels are HomeKit-side and unaffected

Sanitizer behavior: strip disallowed symbols → collapse whitespace → trim leading/trailing non-alphanumerics → fall back to `VeSync Device` if nothing remains. `OasisMist™ 4.5L` → `OasisMist 4.5L`.

## Tests

26 new tests (212 total, all passing; lint and build clean):
- Table-driven sanitizer unit tests: ™/®/emoji stripping, whitespace collapse, leading/trailing punctuation, unicode preservation, valid-name pass-through, fallback paths
- Platform: new accessories and AQ sensors created with sanitized display names; invalid cached names repaired on restore (displayName + info-service Name + `updatePlatformAccessories`); valid cached names left untouched
- Accessory: `Name` characteristic serves the sanitized value while the device object keeps the raw name

## Release

Version bumped to **1.6.1** with a changelog entry — sits directly on top of the just-merged 1.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)